### PR TITLE
fix: fix examples menu list light mode compatibility

### DIFF
--- a/src/components/header/Examples.tsx
+++ b/src/components/header/Examples.tsx
@@ -1,6 +1,7 @@
 import { ChevronDownIcon } from "@chakra-ui/icons";
 import {
   Button,
+  DarkMode,
   Menu,
   MenuButton,
   MenuItem,
@@ -47,26 +48,27 @@ export const Example: React.FC = () => {
 
   return (
     <Menu>
-      <Tooltip
-        shouldWrapChildren
-        hasArrow={!walletPublicKey}
-        label={
-          walletPublicKey
-            ? "Load an example transaction"
-            : "Please connect a wallet to contiune"
-        }
-      >
-        <MenuButton
-          as={Button}
-          rightIcon={<ChevronDownIcon />}
-          variant="ghost"
-          textColor="white"
-          isDisabled={!walletPublicKey}
+      <DarkMode>
+        <Tooltip
+          shouldWrapChildren
+          hasArrow={!walletPublicKey}
+          label={
+            walletPublicKey
+              ? "Load an example transaction"
+              : "Please connect a wallet to contiune"
+          }
         >
-          Examples
-        </MenuButton>
-      </Tooltip>
-
+          <MenuButton
+            as={Button}
+            rightIcon={<ChevronDownIcon />}
+            variant="ghost"
+            textColor="white"
+            isDisabled={!walletPublicKey}
+          >
+            Examples
+          </MenuButton>
+        </Tooltip>
+      </DarkMode>
       <MenuList fontSize="md" zIndex="modal">
         <MenuItem
           onClick={() => {

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -27,8 +27,9 @@ export const Header: React.FC = () => {
     <Flex p="2" bgColor="main.800" alignItems="center">
       <DarkMode>
         <Image w="40px" h="40px" src="/logo128.png" alt="Logo" />
-
-        <Hide below="md">
+      </DarkMode>
+      <Hide below="md">
+        <DarkMode>
           <Text
             ml="3"
             mr="9"
@@ -53,14 +54,14 @@ export const Header: React.FC = () => {
           >
             Better Call Sol
           </Text>
+        </DarkMode>
+        <Example />
+      </Hide>
 
-          <Example />
-        </Hide>
+      <Spacer />
 
-        <Spacer />
-
-        {/* TODO implement */}
-        {/* <Hide below="md">
+      {/* TODO implement */}
+      {/* <Hide below="md">
           <Tooltip label="Undo">
             <IconButton
               mr="0.5"
@@ -82,7 +83,7 @@ export const Header: React.FC = () => {
             />
           </Tooltip>
         </Hide> */}
-      </DarkMode>
+
 
       <ColorModeSwitcher justifySelf="flex-end" />
 


### PR DESCRIPTION
fix the background color of examples menu list when it is in light mode