### PR TITLE
feat: add a switch button to encode and decode raw instruction data between base58 and hex

### DIFF
--- a/src/components/client/TransactionHeader.tsx
+++ b/src/components/client/TransactionHeader.tsx
@@ -15,7 +15,7 @@ import {
   Tooltip,
 } from "@chakra-ui/react";
 import { useWallet } from "@solana/wallet-adapter-react";
-import React from "react";
+import React, { useEffect } from "react";
 import {
   FaCompress,
   FaEllipsisV,
@@ -33,8 +33,9 @@ import {
 import { ITransaction } from "../../types/internal";
 import { DEFAULT_TRANSACTION_RUN, EMPTY_TRANSACTION } from "../../utils/state";
 import { RpcEndpointMenu } from "../common/RpcEndpointMenu";
+import { usePersistentStore } from "../../hooks/usePersistentStore";
 
-export const TransactionHeader: React.FC<{ transaction: ITransaction }> = ({
+export const TransactionHeader: React.FC<{transaction: ITransaction}> = ({
   transaction,
 }) => {
   const [transactionRun, setUI] = useSessionStoreWithoutUndo((state) => [
@@ -44,6 +45,9 @@ export const TransactionHeader: React.FC<{ transaction: ITransaction }> = ({
   const [rpcEndpoint, setSession] = useSessionStoreWithUndo((state) => [
     state.rpcEndpoint,
     state.set,
+  ]);
+  const [rpcEndpoints] = usePersistentStore((state) => [
+    state.appOptions.rpcEndpoints,
   ]);
 
   const { publicKey: walletPublicKey } = useWallet();
@@ -67,6 +71,15 @@ export const TransactionHeader: React.FC<{ transaction: ITransaction }> = ({
       });
     });
   };
+
+  useEffect(() => {
+    // update selected endpoint on endpoint settings change
+    if (rpcEndpoints.map.hasOwnProperty(rpcEndpoint.id)) {
+      setSession((state) => {
+        state.rpcEndpoint = rpcEndpoints.map[rpcEndpoint.id];
+      });
+    }
+  }, [rpcEndpoints])
 
   return (
     <>

--- a/src/components/client/TransactionHeader.tsx
+++ b/src/components/client/TransactionHeader.tsx
@@ -88,7 +88,7 @@ export const TransactionHeader: React.FC<{ transaction: ITransaction }> = ({
           label={
             walletPublicKey
               ? "Run Transaction"
-              : "Please connect a wallet to contiune"
+              : "Please connect a wallet to continue"
           }
         >
           <Button

--- a/src/components/client/TransactionHeader.tsx
+++ b/src/components/client/TransactionHeader.tsx
@@ -73,6 +73,15 @@ export const TransactionHeader: React.FC<{transaction: ITransaction}> = ({
   };
 
   useEffect(() => {
+    if (rpcEndpoints.order.length > 0) {
+      // take the first rpc endpoint as initial value if local storage exists
+      setSession((state) => {
+        state.rpcEndpoint = rpcEndpoints.map[rpcEndpoints.order[0]]
+      });
+    }
+  }, [])
+
+  useEffect(() => {
     // update selected endpoint on endpoint settings change
     if (rpcEndpoints.map.hasOwnProperty(rpcEndpoint.id)) {
       setSession((state) => {

--- a/src/components/client/data/Data.tsx
+++ b/src/components/client/data/Data.tsx
@@ -1,10 +1,8 @@
 import { LockIcon } from "@chakra-ui/icons";
 import {
-  Box,
   Divider,
   Flex,
   Heading,
-  Icon,
   Tab,
   TabList,
   TabPanel,
@@ -12,23 +10,17 @@ import {
   TabProps,
   Tabs,
   useColorModeValue,
-  useToast,
 } from "@chakra-ui/react";
 import React from "react";
 import { useInstruction } from "../../../hooks/useInstruction";
 import { IInstructionData } from "../../../types/internal";
 import { DataEditor } from "./editor/DataEditor";
 import { RawData } from "./RawData";
-import { ToggleIconButton } from "../../common/ToggleIconButton";
-import { HiOutlineSwitchHorizontal } from "react-icons/hi";
-import bs58 from "bs58";
 
 export const Data: React.FC<{data: IInstructionData}> = ({
-  data: { format, raw, isHex, borsh, bufferLayout },
+  data: { format, raw, borsh, bufferLayout },
 }) => {
   const { isAnchor, update } = useInstruction();
-
-  const toast = useToast();
 
   const tabStyle: TabProps = {
     mr: "1",
@@ -69,54 +61,18 @@ export const Data: React.FC<{data: IInstructionData}> = ({
           });
         }}
       >
-        <Box display="flex">
-          <TabList>
-            <Tab {...tabStyle} rounded="md">
-              Borsh{" "}
-              {isAnchor && <LockIcon ml="1" w="2.5" color={lockedIconColor} />}
-            </Tab>
-            <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
-              Buffer Layout
-            </Tab>
-            <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
-              Raw
-            </Tab>
-          </TabList>
-          {
-            format === "raw" ? <Box ml="auto">
-              <ToggleIconButton
-                ml="1"
-                size="sm"
-                label={isHex ? "Click to use encoded data" : "Click to use hex data"}
-                icon={<Icon as={HiOutlineSwitchHorizontal} />}
-                isDisabled={isAnchor}
-                toggled={!isHex}
-                onToggle={(toggled) => {
-                  update((state) => {
-                    if (isHex) {
-                      state.data.raw = bs58.encode(Buffer.from(raw, 'hex'));
-                      state.data.isHex = !isHex;
-                    } else {
-                      try {
-                        state.data.raw = Buffer.from(bs58.decode(raw)).toString('hex');
-                        state.data.isHex = !isHex;
-                      } catch (e) {
-                        // it is not a valid base58 string
-                        toast({
-                          title: "Invalid string",
-                          description: "This is not a valid base58 encoded string.",
-                          status: "error",
-                          isClosable: true,
-                          duration: 30_000,
-                        });
-                      }
-                    }
-                  });
-                }}
-              />
-            </Box> : <></>
-          }
-        </Box>
+        <TabList>
+          <Tab {...tabStyle} rounded="md">
+            Borsh{" "}
+            {isAnchor && <LockIcon ml="1" w="2.5" color={lockedIconColor} />}
+          </Tab>
+          <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
+            Buffer Layout
+          </Tab>
+          <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
+            Raw
+          </Tab>
+        </TabList>
 
         <TabPanels>
           <TabPanel p="0" pt="3">
@@ -126,7 +82,7 @@ export const Data: React.FC<{data: IInstructionData}> = ({
             <DataEditor format="bufferLayout" fields={bufferLayout} />
           </TabPanel>
           <TabPanel p="0" pt="3">
-            <RawData data={raw} isHex={isHex} />
+            <RawData data={raw} />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/src/components/client/data/Data.tsx
+++ b/src/components/client/data/Data.tsx
@@ -1,8 +1,10 @@
 import { LockIcon } from "@chakra-ui/icons";
 import {
+  Box,
   Divider,
   Flex,
   Heading,
+  Icon,
   Tab,
   TabList,
   TabPanel,
@@ -10,17 +12,23 @@ import {
   TabProps,
   Tabs,
   useColorModeValue,
+  useToast,
 } from "@chakra-ui/react";
 import React from "react";
 import { useInstruction } from "../../../hooks/useInstruction";
 import { IInstructionData } from "../../../types/internal";
 import { DataEditor } from "./editor/DataEditor";
 import { RawData } from "./RawData";
+import { ToggleIconButton } from "../../common/ToggleIconButton";
+import { HiOutlineSwitchHorizontal } from "react-icons/hi";
+import bs58 from "bs58";
 
-export const Data: React.FC<{ data: IInstructionData }> = ({
-  data: { format, raw, borsh, bufferLayout },
+export const Data: React.FC<{data: IInstructionData}> = ({
+  data: { format, raw, isHex, borsh, bufferLayout },
 }) => {
   const { isAnchor, update } = useInstruction();
+
+  const toast = useToast();
 
   const tabStyle: TabProps = {
     mr: "1",
@@ -61,18 +69,55 @@ export const Data: React.FC<{ data: IInstructionData }> = ({
           });
         }}
       >
-        <TabList>
-          <Tab {...tabStyle} rounded="md">
-            Borsh{" "}
-            {isAnchor && <LockIcon ml="1" w="2.5" color={lockedIconColor} />}
-          </Tab>
-          <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
-            Buffer Layout
-          </Tab>
-          <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
-            Raw
-          </Tab>
-        </TabList>
+        <Box display="flex">
+          <TabList>
+            <Tab {...tabStyle} rounded="md">
+              Borsh{" "}
+              {isAnchor && <LockIcon ml="1" w="2.5" color={lockedIconColor} />}
+            </Tab>
+            <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
+              Buffer Layout
+            </Tab>
+            <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
+              Raw
+            </Tab>
+          </TabList>
+          {
+            format === "raw" ? <Box ml="auto">
+              <ToggleIconButton
+                ml="1"
+                size="sm"
+                label={isHex ? "Click to use encoded data" : "Click to use hex data"}
+                icon={<Icon as={HiOutlineSwitchHorizontal} />}
+                isDisabled={isAnchor}
+                toggled={!isHex}
+                onToggle={(toggled) => {
+                  update((state) => {
+                    if (isHex) {
+                      state.data.raw = bs58.encode(Buffer.from(raw, 'hex'));
+                      state.data.isHex = !isHex;
+                    } else {
+                      try {
+                        state.data.raw = Buffer.from(bs58.decode(raw)).toString('hex');
+                        state.data.isHex = !isHex;
+                      } catch (e) {
+                        // it is not a valid base58 string
+                        toast({
+                          title: "Invalid string",
+                          description: "This is not a valid base58 encoded string.",
+                          status: "error",
+                          isClosable: true,
+                          duration: 30_000,
+                        });
+                      }
+                    }
+                  });
+                }}
+              />
+            </Box> : <></>
+          }
+        </Box>
+
         <TabPanels>
           <TabPanel p="0" pt="3">
             <DataEditor format="borsh" fields={borsh} />
@@ -81,10 +126,11 @@ export const Data: React.FC<{ data: IInstructionData }> = ({
             <DataEditor format="bufferLayout" fields={bufferLayout} />
           </TabPanel>
           <TabPanel p="0" pt="3">
-            <RawData data={raw} />
+            <RawData data={raw} isHex={isHex} />
           </TabPanel>
         </TabPanels>
       </Tabs>
     </>
   );
 };
+

--- a/src/components/client/data/RawData.tsx
+++ b/src/components/client/data/RawData.tsx
@@ -1,21 +1,68 @@
-import { Textarea } from "@chakra-ui/react";
+import {
+  Box,
+  Icon,
+  Textarea,
+  useToast
+} from "@chakra-ui/react";
 import React from "react";
 import { useInstruction } from "../../../hooks/useInstruction";
+import { IRaw } from "../../../types/internal";
+import { ToggleIconButton } from "../../common/ToggleIconButton";
+import { HiOutlineSwitchHorizontal } from "react-icons/hi";
+import bs58 from "bs58";
 
-export const RawData: React.FC<{data: string, isHex: boolean}> = ({ data, isHex }) => {
+export const RawData: React.FC<{data: IRaw}> = ({ data }) => {
   const { update } = useInstruction();
 
+  const toast = useToast();
+
+  const onToggle = () => {
+    update((state) => {
+      if (data.encoding === "hex") {
+        state.data.raw.content = bs58.encode(Buffer.from(data.content, 'hex'));
+        state.data.raw.encoding = "bs58";
+      } else {
+        try {
+          state.data.raw.content = Buffer.from(bs58.decode(state.data.raw.content)).toString('hex');
+          state.data.raw.encoding = "hex";
+        } catch (e) {
+          // it is not a valid base58 string
+          toast({
+            title: "Invalid string",
+            description: "This is not a valid base58 encoded string.",
+            status: "error",
+            isClosable: true,
+            duration: 30_000,
+          });
+        }
+      }
+    });
+  }
+
   return (
-    <Textarea
-      flex="1"
-      fontFamily="mono"
-      placeholder={isHex ? "Instruction data (hex)" : "Instruction data (base58 encoded)"}
-      value={data}
-      onChange={(e) => {
-        update((state) => {
-          state.data.raw = e.target.value;
-        });
-      }}
-    />
+    <Box display="flex">
+      <Textarea
+        flex="1"
+        fontFamily="mono"
+        placeholder={data.encoding === "hex" ? "Instruction data (hex)" : "Instruction data (base58 encoded)"}
+        value={data.content}
+        onChange={(e) => {
+          update((state) => {
+            state.data.raw.content = e.target.value;
+          });
+        }}
+      />
+
+      <Box ml="auto" mt="auto">
+        <ToggleIconButton
+          ml="1"
+          size="sm"
+          label={data.encoding === "hex" ? "Click to use encoded data" : "Click to use hex data"}
+          icon={<Icon as={HiOutlineSwitchHorizontal} />}
+          toggled={data.encoding !== "hex"}
+          onToggle={onToggle}
+        />
+      </Box>
+    </Box>
   );
 };

--- a/src/components/client/data/RawData.tsx
+++ b/src/components/client/data/RawData.tsx
@@ -2,14 +2,14 @@ import { Textarea } from "@chakra-ui/react";
 import React from "react";
 import { useInstruction } from "../../../hooks/useInstruction";
 
-export const RawData: React.FC<{ data: string }> = ({ data }) => {
+export const RawData: React.FC<{data: string, isHex: boolean}> = ({ data, isHex }) => {
   const { update } = useInstruction();
 
   return (
     <Textarea
       flex="1"
       fontFamily="mono"
-      placeholder="Instruction data"
+      placeholder={isHex ? "Instruction data (hex)" : "Instruction data (base58 encoded)"}
       value={data}
       onChange={(e) => {
         update((state) => {

--- a/src/components/common/ExplorerButton.tsx
+++ b/src/components/common/ExplorerButton.tsx
@@ -27,7 +27,7 @@ const explorerOpts: Record<Exclude<Explorer, "none">,
   }> = {
   solana: {
     label: "Open in Solana Explorer",
-    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "local"],
+    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "custom"],
     url: (valueType, value, rpcEndpoint) =>
       `https://explorer.solana.com/${
         valueType === "account" ? "address" : valueType
@@ -37,7 +37,7 @@ const explorerOpts: Record<Exclude<Explorer, "none">,
   },
   solanafm: {
     label: "Open in SolanaFM",
-    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "local"],
+    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "custom"],
     url: (valueType, value, rpcEndpoint) =>
       `https://solana.fm/${
         valueType === "account" ? "address" : valueType
@@ -65,7 +65,7 @@ const explorerOpts: Record<Exclude<Explorer, "none">,
   },
   solscan: {
     label: "Open in Solscan",
-    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "local"],
+    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "custom"],
     url: (valueType, value, rpcEndpoint) =>
       `https://solscan.io/${valueType}/${value}?cluster=${
         rpcEndpoint.custom ? "custom" : rpcEndpoint.network

--- a/src/components/common/ExplorerButton.tsx
+++ b/src/components/common/ExplorerButton.tsx
@@ -15,8 +15,7 @@ import { Explorer } from "../../types/state";
 
 export type AddressType = "tx" | "account";
 
-const explorerOpts: Record<
-  Exclude<Explorer, "none">,
+const explorerOpts: Record<Exclude<Explorer, "none">,
   {
     label: string;
     supportedNetworks: INetwork[];
@@ -25,15 +24,16 @@ const explorerOpts: Record<
       value: string,
       rpcEndpoint: IRpcEndpoint
     ) => string;
-  }
-> = {
+  }> = {
   solana: {
     label: "Open in Solana Explorer",
-    supportedNetworks: ["devnet", "testnet", "mainnet-beta"],
+    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "local"],
     url: (valueType, value, rpcEndpoint) =>
       `https://explorer.solana.com/${
         valueType === "account" ? "address" : valueType
-      }/${value}?cluster=${rpcEndpoint.network}`,
+      }/${value}?cluster=${
+        rpcEndpoint.custom ? "custom" : rpcEndpoint.network
+      }${rpcEndpoint.custom ? "&customUrl=" + rpcEndpoint.url : ""}`,
   },
   solanafm: {
     label: "Open in SolanaFM",
@@ -43,12 +43,12 @@ const explorerOpts: Record<
         valueType === "account" ? "address" : valueType
       }/${value}?cluster=${
         rpcEndpoint.custom
-          ? rpcEndpoint.custom
+          ? rpcEndpoint.url
           : rpcEndpoint.network === "devnet"
-          ? "devnet-qn1"
-          : rpcEndpoint.network === "testnet"
-          ? "testnet-qn1"
-          : "mainnet-qn1"
+            ? "devnet-qn1"
+            : rpcEndpoint.network === "testnet"
+              ? "testnet-qn1"
+              : "mainnet-qn1"
       }`,
   },
   solanaBeach: {
@@ -73,13 +73,11 @@ const explorerOpts: Record<
   },
 };
 
-export const ExplorerButton: React.FC<
-  {
-    value: string;
-    valueType: AddressType;
-    rpcEndpoint: IRpcEndpoint;
-  } & Omit<ButtonProps, "aria-label">
-> = ({
+export const ExplorerButton: React.FC<{
+  value: string;
+  valueType: AddressType;
+  rpcEndpoint: IRpcEndpoint;
+} & Omit<ButtonProps, "aria-label">> = ({
   value,
   valueType,
   rpcEndpoint,
@@ -137,7 +135,7 @@ export const ExplorerButton: React.FC<
   );
 };
 
-const SolscanIcon: React.FC<{ size: any }> = ({ size }) => (
+const SolscanIcon: React.FC<{size: any}> = ({ size }) => (
   <Icon
     w={size === "xs" ? 3 : size === "sm" ? 4 : 5}
     h={size === "xs" ? 3 : size === "sm" ? 4 : 5}
@@ -156,7 +154,7 @@ const SolscanIcon: React.FC<{ size: any }> = ({ size }) => (
   </Icon>
 );
 
-const SolanaExplorerIcon: React.FC<{ size: any }> = ({ size }) => (
+const SolanaExplorerIcon: React.FC<{size: any}> = ({ size }) => (
   <Icon
     w={size === "xs" ? 3 : size === "sm" ? 4 : 5}
     h={size === "xs" ? 3 : size === "sm" ? 4 : 5}
@@ -175,7 +173,7 @@ const SolanaExplorerIcon: React.FC<{ size: any }> = ({ size }) => (
   </Icon>
 );
 
-const SolanaFmIcon: React.FC<{ size: any }> = ({ size }) => {
+const SolanaFmIcon: React.FC<{size: any}> = ({ size }) => {
   const fillColour = useColorModeValue("black", "white");
 
   return (
@@ -213,7 +211,7 @@ const SolanaFmIcon: React.FC<{ size: any }> = ({ size }) => {
   );
 };
 
-const SolanaBeachIcon: React.FC<{ size: any }> = ({ size }) => (
+const SolanaBeachIcon: React.FC<{size: any}> = ({ size }) => (
   <Icon
     w={size === "xs" ? 3 : size === "sm" ? 4 : 5}
     h={size === "xs" ? 3 : size === "sm" ? 4 : 5}

--- a/src/components/common/RpcEndpointMenu.tsx
+++ b/src/components/common/RpcEndpointMenu.tsx
@@ -55,7 +55,7 @@ export const RpcEndpointMenu: React.FC<{
             .filter(({ enabled, url }) => enabled && url)
             .map((it, index) => (
               <MenuItem
-                icon={endpoint.url === it.url ? <CheckIcon /> : undefined}
+                icon={endpoint.id === it.id ? <CheckIcon /> : undefined}
                 key={index}
                 command={it.provider}
                 onClick={() => {

--- a/src/components/header/Examples.tsx
+++ b/src/components/header/Examples.tsx
@@ -53,7 +53,7 @@ export const Example: React.FC = () => {
         label={
           walletPublicKey
             ? "Load an example transaction"
-            : "Please connect a wallet to contiune"
+            : "Please connect a wallet to continue"
         }
       >
         <MenuButton

--- a/src/components/options/fields/RpcEndpointOption.tsx
+++ b/src/components/options/fields/RpcEndpointOption.tsx
@@ -15,6 +15,7 @@ import { usePersistentStore } from "../../../hooks/usePersistentStore";
 import { INetwork, IRpcEndpoint } from "../../../types/internal";
 import { removeFrom } from "../../../utils/sortable";
 import { SortableItemContext } from "../../common/Sortable";
+import { RPC_NETWORK_OPTIONS } from "../../../utils/state";
 
 const isValidUrl = (url: string) => {
   try {
@@ -79,7 +80,7 @@ export const RpcEndpointOption: React.FC<IRpcEndpoint> = ({
               })
             }
           >
-            {["devnet", "testnet", "mainnet-beta"].map((n) => (
+            {RPC_NETWORK_OPTIONS.map((n) => (
               <option key={n} value={n}>
                 {n}
               </option>

--- a/src/components/options/fields/RpcEndpointOption.tsx
+++ b/src/components/options/fields/RpcEndpointOption.tsx
@@ -136,7 +136,7 @@ export const RpcEndpointOption: React.FC<IRpcEndpoint> = ({
           isInvalid={!isValidUrl(notValidatedUrl)}
           onChange={(e) => {
             setNotValidatedUrl(e.target.value);
-            setUrl(notValidatedUrl);
+            setUrl(e.target.value);
           }}
         />
       </Grid>

--- a/src/mappers/external-to-internal.ts
+++ b/src/mappers/external-to-internal.ts
@@ -46,22 +46,24 @@ export const mapIInstructionExtToIInstruction = ({
     accounts: mapToSortableCollection(accounts.map(mpaIAccountExtToIAccount)),
     data: {
       format: data.format,
-      raw: data.format === "raw" ? (data.value as string) : "",
-      isHex: false,
+      raw: {
+        content: data.format === "raw" ? (data.value as string) : "",
+        encoding: "bs58"
+      },
       borsh: mapToSortableCollection(
         data.format === "borsh"
           ? (data.value as IInstrctionDataFieldExt[]).map((v) => ({
-              id: uuid(),
-              ...v,
-            }))
+            id: uuid(),
+            ...v,
+          }))
           : []
       ),
       bufferLayout: mapToSortableCollection(
         data.format === "bufferLayout"
           ? (data.value as IInstrctionDataFieldExt[]).map((v) => ({
-              id: uuid(),
-              ...v,
-            }))
+            id: uuid(),
+            ...v,
+          }))
           : []
       ),
     },

--- a/src/mappers/external-to-internal.ts
+++ b/src/mappers/external-to-internal.ts
@@ -47,6 +47,7 @@ export const mapIInstructionExtToIInstruction = ({
     data: {
       format: data.format,
       raw: data.format === "raw" ? (data.value as string) : "",
+      isHex: false,
       borsh: mapToSortableCollection(
         data.format === "borsh"
           ? (data.value as IInstrctionDataFieldExt[]).map((v) => ({

--- a/src/mappers/internal-to-external.ts
+++ b/src/mappers/internal-to-external.ts
@@ -9,6 +9,7 @@ import {
   ITransaction,
 } from "../types/internal";
 import { toSortedArray } from "../utils/sortable";
+import bs58 from "bs58";
 
 const mapIAccountToIAccountExt = ({
   name,
@@ -48,8 +49,10 @@ export const mapITransactionToTransactionExt = ({
           data.format === "borsh"
             ? toSortedArray(data.borsh).map(mapToIInstrctionDataFieldExt)
             : data.format === "bufferLayout"
-            ? toSortedArray(data.bufferLayout).map(mapToIInstrctionDataFieldExt)
-            : data.raw,
+              ? toSortedArray(data.bufferLayout).map(mapToIInstrctionDataFieldExt)
+              : data.raw.encoding === "hex"
+                ? bs58.encode(Buffer.from(data.raw.content, 'hex'))
+                : data.raw.content,
       },
       anchorMethod,
       anchorAccounts: anchorAccounts?.map(mapIAccountToIAccountExt),

--- a/src/mappers/internal-to-web3js.ts
+++ b/src/mappers/internal-to-web3js.ts
@@ -33,7 +33,11 @@ export const mapITransactionToWeb3Transaction = ({
             toSortedArray(data.bufferLayout)
           );
         } else if (data.format === "raw" && data.raw) {
-          buffer = Buffer.from(bs58.decode(data.raw));
+          if (data.isHex) {
+            buffer = Buffer.from(data.raw, 'hex');
+          } else {
+            buffer = Buffer.from(bs58.decode(data.raw));
+          }
         }
       } catch (err) {
         const message = Object.getOwnPropertyNames(err).includes("message")

--- a/src/mappers/internal-to-web3js.ts
+++ b/src/mappers/internal-to-web3js.ts
@@ -8,6 +8,7 @@ import { BufferLayoutCoder } from "../coders/buffer-layout";
 import { ITransaction } from "../types/internal";
 import { toSortedArray } from "../utils/sortable";
 import { anchorMethodSighash } from "../utils/web3js";
+import bs58 from "bs58";
 
 export const mapITransactionToWeb3Transaction = ({
   instructions,
@@ -31,7 +32,7 @@ export const mapITransactionToWeb3Transaction = ({
           toSortedArray(data.bufferLayout)
         );
       } else if (data.format === "raw" && data.raw) {
-        buffer = Buffer.from(data.raw);
+        buffer = Buffer.from(bs58.decode(data.raw));
       }
 
       // accounts

--- a/src/mappers/web3js-to-internal.ts
+++ b/src/mappers/web3js-to-internal.ts
@@ -26,7 +26,7 @@ export const mapWeb3TransactionError = (err: any): string => {
     const errObject = err as Record<string, any>;
     if (errObject?.InstructionError) {
       const [index, errorCode] = errObject.InstructionError;
-      error = `Error at Instruction ${index}: ${JSON.stringify(errorCode)}`;
+      error = `Error at Instruction #${index + 1}: ${JSON.stringify(errorCode)}`;
     }
   }
 

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -44,10 +44,14 @@ export interface IInstrctionDataField {
 
 export type DataFormat = "raw" | "bufferLayout" | "borsh";
 
+export interface IRaw {
+  content: string;
+  encoding: "hex" | "bs58"
+}
+
 export interface IInstructionData {
   format: DataFormat;
-  raw: string;
-  isHex: boolean;
+  raw: IRaw;
   borsh: SortableCollection<IInstrctionDataField>;
   bufferLayout: SortableCollection<IInstrctionDataField>;
 }

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -47,6 +47,7 @@ export type DataFormat = "raw" | "bufferLayout" | "borsh";
 export interface IInstructionData {
   format: DataFormat;
   raw: string;
+  isHex: boolean;
   borsh: SortableCollection<IInstrctionDataField>;
   bufferLayout: SortableCollection<IInstrctionDataField>;
 }

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -75,7 +75,7 @@ export interface IInstruction {
   readonly expanded: boolean;
 }
 
-export type INetwork = "local" | "devnet" | "testnet" | "mainnet-beta";
+export type INetwork = "custom" | "devnet" | "testnet" | "mainnet-beta";
 
 export interface IRpcEndpoint {
   id: IID;

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -35,8 +35,10 @@ export const newAccount = (): IAccount => ({
 
 export const EMPTY_INSTRUCTION_DATA: IInstructionData = {
   format: "raw",
-  raw: "",
-  isHex: false,
+  raw: {
+    content: "",
+    encoding: "bs58"
+  },
   borsh: toSortableCollection([]),
   bufferLayout: toSortableCollection([]),
 };

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -36,6 +36,7 @@ export const newAccount = (): IAccount => ({
 export const EMPTY_INSTRUCTION_DATA: IInstructionData = {
   format: "raw",
   raw: "",
+  isHex: false,
   borsh: toSortableCollection([]),
   bufferLayout: toSortableCollection([]),
 };

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -51,8 +51,8 @@ export const DEFAULT_RPC_ENDPOINTS: IRpcEndpoint[] = [
   },
   {
     id: uuid(),
-    provider: "You",
-    network: "local",
+    provider: "Localhost",
+    network: "custom",
     url: "http://127.0.0.1:8899",
     enabled: true,
     custom: true,
@@ -103,7 +103,8 @@ export const DEFAULT_SESSION_STATE_WITH_UNDO: SessionStateWithUndo = {
   transaction: DEFAULT_TRANSACTION,
   rpcEndpoint: DEFAULT_RPC_ENDPOINTS[0],
   keypairs: {},
-  set: () => {}, // set by the hook
+  set: () => {
+  }, // set by the hook
 };
 
 export const DEFAULT_SESSION_STATE_WITHOUT_UNDO: SessionStateWithoutUndo = {
@@ -115,12 +116,14 @@ export const DEFAULT_SESSION_STATE_WITHOUT_UNDO: SessionStateWithoutUndo = {
     infoOpen: false,
   },
   import: DEFAULT_IMPORT,
-  set: () => {}, // set by the hook
+  set: () => {
+  }, // set by the hook
 };
 
 export const DEFAULT_PERSISTENT_STATE: PersistentState = {
   transactionOptions: DEFAUT_TRANSACTION_OPTIONS,
   appOptions: DEFAULT_APP_OPTIONS,
   firstTime: true,
-  set: () => {}, // set by the hook
+  set: () => {
+  }, // set by the hook
 };

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -16,6 +16,8 @@ import {
 import { newAccount, newInstruction } from "./internal";
 import { toSortableCollection } from "./sortable";
 
+export const RPC_NETWORK_OPTIONS: string[] = ["devnet", "testnet", "mainnet-beta", "custom"];
+
 export const DEFAULT_RPC_ENDPOINTS: IRpcEndpoint[] = [
   {
     id: uuid(),


### PR DESCRIPTION
## Description
* Fix invalid instruction data when using raw data to send a transaction
* Include instruction index, instruction account index in error message when mapping internal transaction to web3 transaction
* Add switch button to encode and decode raw instruction data between base58 and hex

![Screen Shot 2022-08-17 at 3 44 01 pm](https://user-images.githubusercontent.com/111264560/185043569-c2a5490c-4b90-49b7-ba8d-4339eb587184.png)

## Solution Description
* decode base58 encoded data before adding to Buffer
* add try catch to capture errors in mapping function
* add an additional flag isHex to identity the encoding format of raw data
