### PR TITLE
Add a switch button to encode and decode raw instruction data between base58 and hex, fix explorer with custom rpc, fix adding custom rpc endpoint

### DIFF
--- a/src/components/client/TransactionHeader.tsx
+++ b/src/components/client/TransactionHeader.tsx
@@ -107,7 +107,7 @@ export const TransactionHeader: React.FC<{
           label={
             walletPublicKey
               ? "Run Transaction"
-              : "Please connect a wallet to contiune"
+              : "Please connect a wallet to continue"
           }
         >
           <Button

--- a/src/components/client/data/Data.tsx
+++ b/src/components/client/data/Data.tsx
@@ -1,10 +1,8 @@
 import { LockIcon } from "@chakra-ui/icons";
 import {
-  Box,
   Divider,
   Flex,
   Heading,
-  Icon,
   Tab,
   TabList,
   TabPanel,
@@ -12,23 +10,17 @@ import {
   TabProps,
   Tabs,
   useColorModeValue,
-  useToast,
 } from "@chakra-ui/react";
 import React from "react";
 import { useInstruction } from "../../../hooks/useInstruction";
 import { IInstructionData } from "../../../types/internal";
 import { DataEditor } from "./editor/DataEditor";
 import { RawData } from "./RawData";
-import { ToggleIconButton } from "../../common/ToggleIconButton";
-import { HiOutlineSwitchHorizontal } from "react-icons/hi";
-import bs58 from "bs58";
 
 export const Data: React.FC<{data: IInstructionData}> = ({
-  data: { format, raw, isHex, borsh, bufferLayout },
+  data: { format, raw, borsh, bufferLayout },
 }) => {
   const { isAnchor, update } = useInstruction();
-
-  const toast = useToast();
 
   const tabStyle: TabProps = {
     mr: "1",
@@ -69,54 +61,18 @@ export const Data: React.FC<{data: IInstructionData}> = ({
           });
         }}
       >
-        <Box display="flex">
-          <TabList>
-            <Tab {...tabStyle} rounded="md">
-              Borsh{" "}
-              {isAnchor && <LockIcon ml="1" w="2.5" color={lockedIconColor} />}
-            </Tab>
-            <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
-              Buffer Layout
-            </Tab>
-            <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
-              Raw
-            </Tab>
-          </TabList>
-          {
-            format === "raw" ? <Box ml="auto">
-              <ToggleIconButton
-                ml="1"
-                size="sm"
-                label={isHex ? "Click to use encoded data" : "Click to use hex data"}
-                icon={<Icon as={HiOutlineSwitchHorizontal} />}
-                isDisabled={isAnchor}
-                toggled={!isHex}
-                onToggle={(toggled) => {
-                  update((state) => {
-                    if (isHex) {
-                      state.data.raw = bs58.encode(Buffer.from(raw, 'hex'));
-                      state.data.isHex = !isHex;
-                    } else {
-                      try {
-                        state.data.raw = Buffer.from(bs58.decode(raw)).toString('hex');
-                        state.data.isHex = !isHex;
-                      } catch (e) {
-                        // it is not a valid base58 string
-                        toast({
-                          title: "Invalid string",
-                          description: "This is not a valid base58 encoded string.",
-                          status: "error",
-                          isClosable: true,
-                          duration: 30_000,
-                        });
-                      }
-                    }
-                  });
-                }}
-              />
-            </Box> : <></>
-          }
-        </Box>
+        <TabList>
+          <Tab {...tabStyle} rounded="md">
+            Borsh{" "}
+            {isAnchor && <LockIcon ml="1" w="2.5" color={lockedIconColor} />}
+          </Tab>
+          <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
+            Buffer Layout
+          </Tab>
+          <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
+            Raw
+          </Tab>
+        </TabList>
 
         <TabPanels>
           <TabPanel p="0" pt="3">
@@ -126,7 +82,7 @@ export const Data: React.FC<{data: IInstructionData}> = ({
             <DataEditor format="bufferLayout" fields={bufferLayout} />
           </TabPanel>
           <TabPanel p="0" pt="3">
-            <RawData data={raw} isHex={isHex} />
+            <RawData data={raw} />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/src/components/client/data/Data.tsx
+++ b/src/components/client/data/Data.tsx
@@ -17,7 +17,7 @@ import { IInstructionData } from "../../../types/internal";
 import { DataEditor } from "./editor/DataEditor";
 import { RawData } from "./RawData";
 
-export const Data: React.FC<{data: IInstructionData}> = ({
+export const Data: React.FC<{ data: IInstructionData }> = ({
   data: { format, raw, borsh, bufferLayout },
 }) => {
   const { isAnchor, update } = useInstruction();
@@ -89,4 +89,3 @@ export const Data: React.FC<{data: IInstructionData}> = ({
     </>
   );
 };
-

--- a/src/components/client/data/Data.tsx
+++ b/src/components/client/data/Data.tsx
@@ -1,8 +1,10 @@
 import { LockIcon } from "@chakra-ui/icons";
 import {
+  Box,
   Divider,
   Flex,
   Heading,
+  Icon,
   Tab,
   TabList,
   TabPanel,
@@ -10,17 +12,23 @@ import {
   TabProps,
   Tabs,
   useColorModeValue,
+  useToast,
 } from "@chakra-ui/react";
 import React from "react";
 import { useInstruction } from "../../../hooks/useInstruction";
 import { IInstructionData } from "../../../types/internal";
 import { DataEditor } from "./editor/DataEditor";
 import { RawData } from "./RawData";
+import { ToggleIconButton } from "../../common/ToggleIconButton";
+import { HiOutlineSwitchHorizontal } from "react-icons/hi";
+import bs58 from "bs58";
 
-export const Data: React.FC<{ data: IInstructionData }> = ({
-  data: { format, raw, borsh, bufferLayout },
+export const Data: React.FC<{data: IInstructionData}> = ({
+  data: { format, raw, isHex, borsh, bufferLayout },
 }) => {
   const { isAnchor, update } = useInstruction();
+
+  const toast = useToast();
 
   const tabStyle: TabProps = {
     mr: "1",
@@ -61,18 +69,55 @@ export const Data: React.FC<{ data: IInstructionData }> = ({
           });
         }}
       >
-        <TabList>
-          <Tab {...tabStyle} rounded="md">
-            Borsh{" "}
-            {isAnchor && <LockIcon ml="1" w="2.5" color={lockedIconColor} />}
-          </Tab>
-          <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
-            Buffer Layout
-          </Tab>
-          <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
-            Raw
-          </Tab>
-        </TabList>
+        <Box display="flex">
+          <TabList>
+            <Tab {...tabStyle} rounded="md">
+              Borsh{" "}
+              {isAnchor && <LockIcon ml="1" w="2.5" color={lockedIconColor} />}
+            </Tab>
+            <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
+              Buffer Layout
+            </Tab>
+            <Tab {...tabStyle} rounded="md" isDisabled={isAnchor}>
+              Raw
+            </Tab>
+          </TabList>
+          {
+            format === "raw" ? <Box ml="auto">
+              <ToggleIconButton
+                ml="1"
+                size="sm"
+                label={isHex ? "Click to use encoded data" : "Click to use hex data"}
+                icon={<Icon as={HiOutlineSwitchHorizontal} />}
+                isDisabled={isAnchor}
+                toggled={!isHex}
+                onToggle={(toggled) => {
+                  update((state) => {
+                    if (isHex) {
+                      state.data.raw = bs58.encode(Buffer.from(raw, 'hex'));
+                      state.data.isHex = !isHex;
+                    } else {
+                      try {
+                        state.data.raw = Buffer.from(bs58.decode(raw)).toString('hex');
+                        state.data.isHex = !isHex;
+                      } catch (e) {
+                        // it is not a valid base58 string
+                        toast({
+                          title: "Invalid string",
+                          description: "This is not a valid base58 encoded string.",
+                          status: "error",
+                          isClosable: true,
+                          duration: 30_000,
+                        });
+                      }
+                    }
+                  });
+                }}
+              />
+            </Box> : <></>
+          }
+        </Box>
+
         <TabPanels>
           <TabPanel p="0" pt="3">
             <DataEditor format="borsh" fields={borsh} />
@@ -81,10 +126,11 @@ export const Data: React.FC<{ data: IInstructionData }> = ({
             <DataEditor format="bufferLayout" fields={bufferLayout} />
           </TabPanel>
           <TabPanel p="0" pt="3">
-            <RawData data={raw} />
+            <RawData data={raw} isHex={isHex} />
           </TabPanel>
         </TabPanels>
       </Tabs>
     </>
   );
 };
+

--- a/src/components/client/data/RawData.tsx
+++ b/src/components/client/data/RawData.tsx
@@ -1,21 +1,68 @@
-import { Textarea } from "@chakra-ui/react";
+import {
+  Box,
+  Icon,
+  Textarea,
+  useToast
+} from "@chakra-ui/react";
 import React from "react";
 import { useInstruction } from "../../../hooks/useInstruction";
+import { IRaw } from "../../../types/internal";
+import { ToggleIconButton } from "../../common/ToggleIconButton";
+import { HiOutlineSwitchHorizontal } from "react-icons/hi";
+import bs58 from "bs58";
 
-export const RawData: React.FC<{data: string, isHex: boolean}> = ({ data, isHex }) => {
+export const RawData: React.FC<{data: IRaw}> = ({ data }) => {
   const { update } = useInstruction();
 
+  const toast = useToast();
+
+  const onToggle = () => {
+    update((state) => {
+      if (data.encoding === "hex") {
+        state.data.raw.content = bs58.encode(Buffer.from(data.content, 'hex'));
+        state.data.raw.encoding = "bs58";
+      } else {
+        try {
+          state.data.raw.content = Buffer.from(bs58.decode(state.data.raw.content)).toString('hex');
+          state.data.raw.encoding = "hex";
+        } catch (e) {
+          // it is not a valid base58 string
+          toast({
+            title: "Invalid string",
+            description: "This is not a valid base58 encoded string.",
+            status: "error",
+            isClosable: true,
+            duration: 30_000,
+          });
+        }
+      }
+    });
+  }
+
   return (
-    <Textarea
-      flex="1"
-      fontFamily="mono"
-      placeholder={isHex ? "Instruction data (hex)" : "Instruction data (base58 encoded)"}
-      value={data}
-      onChange={(e) => {
-        update((state) => {
-          state.data.raw = e.target.value;
-        });
-      }}
-    />
+    <Box display="flex">
+      <Textarea
+        flex="1"
+        fontFamily="mono"
+        placeholder={data.encoding === "hex" ? "Instruction data (hex)" : "Instruction data (base58 encoded)"}
+        value={data.content}
+        onChange={(e) => {
+          update((state) => {
+            state.data.raw.content = e.target.value;
+          });
+        }}
+      />
+
+      <Box ml="auto" mt="auto">
+        <ToggleIconButton
+          ml="1"
+          size="sm"
+          label={data.encoding === "hex" ? "Click to use encoded data" : "Click to use hex data"}
+          icon={<Icon as={HiOutlineSwitchHorizontal} />}
+          toggled={data.encoding !== "hex"}
+          onToggle={onToggle}
+        />
+      </Box>
+    </Box>
   );
 };

--- a/src/components/client/data/RawData.tsx
+++ b/src/components/client/data/RawData.tsx
@@ -1,9 +1,4 @@
-import {
-  Box,
-  Icon,
-  Textarea,
-  useToast
-} from "@chakra-ui/react";
+import { Box, Icon, Textarea, useToast } from "@chakra-ui/react";
 import React from "react";
 import { useInstruction } from "../../../hooks/useInstruction";
 import { IRaw } from "../../../types/internal";
@@ -11,7 +6,7 @@ import { ToggleIconButton } from "../../common/ToggleIconButton";
 import { HiOutlineSwitchHorizontal } from "react-icons/hi";
 import bs58 from "bs58";
 
-export const RawData: React.FC<{data: IRaw}> = ({ data }) => {
+export const RawData: React.FC<{ data: IRaw }> = ({ data }) => {
   const { update } = useInstruction();
 
   const toast = useToast();
@@ -19,11 +14,13 @@ export const RawData: React.FC<{data: IRaw}> = ({ data }) => {
   const onToggle = () => {
     update((state) => {
       if (data.encoding === "hex") {
-        state.data.raw.content = bs58.encode(Buffer.from(data.content, 'hex'));
+        state.data.raw.content = bs58.encode(Buffer.from(data.content, "hex"));
         state.data.raw.encoding = "bs58";
       } else {
         try {
-          state.data.raw.content = Buffer.from(bs58.decode(state.data.raw.content)).toString('hex');
+          state.data.raw.content = Buffer.from(
+            bs58.decode(state.data.raw.content)
+          ).toString("hex");
           state.data.raw.encoding = "hex";
         } catch (e) {
           // it is not a valid base58 string
@@ -37,14 +34,18 @@ export const RawData: React.FC<{data: IRaw}> = ({ data }) => {
         }
       }
     });
-  }
+  };
 
   return (
     <Box display="flex">
       <Textarea
         flex="1"
         fontFamily="mono"
-        placeholder={data.encoding === "hex" ? "Instruction data (hex)" : "Instruction data (base58 encoded)"}
+        placeholder={
+          data.encoding === "hex"
+            ? "Instruction data (hex)"
+            : "Instruction data (base58 encoded)"
+        }
         value={data.content}
         onChange={(e) => {
           update((state) => {
@@ -57,7 +58,11 @@ export const RawData: React.FC<{data: IRaw}> = ({ data }) => {
         <ToggleIconButton
           ml="1"
           size="sm"
-          label={data.encoding === "hex" ? "Click to use encoded data" : "Click to use hex data"}
+          label={
+            data.encoding === "hex"
+              ? "Click to use encoded data"
+              : "Click to use hex data"
+          }
           icon={<Icon as={HiOutlineSwitchHorizontal} />}
           toggled={data.encoding !== "hex"}
           onToggle={onToggle}

--- a/src/components/client/data/RawData.tsx
+++ b/src/components/client/data/RawData.tsx
@@ -2,14 +2,14 @@ import { Textarea } from "@chakra-ui/react";
 import React from "react";
 import { useInstruction } from "../../../hooks/useInstruction";
 
-export const RawData: React.FC<{ data: string }> = ({ data }) => {
+export const RawData: React.FC<{data: string, isHex: boolean}> = ({ data, isHex }) => {
   const { update } = useInstruction();
 
   return (
     <Textarea
       flex="1"
       fontFamily="mono"
-      placeholder="Instruction data"
+      placeholder={isHex ? "Instruction data (hex)" : "Instruction data (base58 encoded)"}
       value={data}
       onChange={(e) => {
         update((state) => {

--- a/src/components/common/ExplorerButton.tsx
+++ b/src/components/common/ExplorerButton.tsx
@@ -15,7 +15,8 @@ import { Explorer } from "../../types/state";
 
 export type AddressType = "tx" | "account";
 
-const explorerOpts: Record<Exclude<Explorer, "none">,
+const explorerOpts: Record<
+  Exclude<Explorer, "none">,
   {
     label: string;
     supportedNetworks: INetwork[];
@@ -24,7 +25,8 @@ const explorerOpts: Record<Exclude<Explorer, "none">,
       value: string,
       rpcEndpoint: IRpcEndpoint
     ) => string;
-  }> = {
+  }
+> = {
   solana: {
     label: "Open in Solana Explorer",
     supportedNetworks: ["devnet", "testnet", "mainnet-beta", "custom"],
@@ -45,10 +47,10 @@ const explorerOpts: Record<Exclude<Explorer, "none">,
         rpcEndpoint.custom
           ? rpcEndpoint.url
           : rpcEndpoint.network === "devnet"
-            ? "devnet-qn1"
-            : rpcEndpoint.network === "testnet"
-              ? "testnet-qn1"
-              : "mainnet-qn1"
+          ? "devnet-qn1"
+          : rpcEndpoint.network === "testnet"
+          ? "testnet-qn1"
+          : "mainnet-qn1"
       }`,
   },
   solanaBeach: {
@@ -73,11 +75,13 @@ const explorerOpts: Record<Exclude<Explorer, "none">,
   },
 };
 
-export const ExplorerButton: React.FC<{
-  value: string;
-  valueType: AddressType;
-  rpcEndpoint: IRpcEndpoint;
-} & Omit<ButtonProps, "aria-label">> = ({
+export const ExplorerButton: React.FC<
+  {
+    value: string;
+    valueType: AddressType;
+    rpcEndpoint: IRpcEndpoint;
+  } & Omit<ButtonProps, "aria-label">
+> = ({
   value,
   valueType,
   rpcEndpoint,
@@ -135,7 +139,7 @@ export const ExplorerButton: React.FC<{
   );
 };
 
-const SolscanIcon: React.FC<{size: any}> = ({ size }) => (
+const SolscanIcon: React.FC<{ size: any }> = ({ size }) => (
   <Icon
     w={size === "xs" ? 3 : size === "sm" ? 4 : 5}
     h={size === "xs" ? 3 : size === "sm" ? 4 : 5}
@@ -154,7 +158,7 @@ const SolscanIcon: React.FC<{size: any}> = ({ size }) => (
   </Icon>
 );
 
-const SolanaExplorerIcon: React.FC<{size: any}> = ({ size }) => (
+const SolanaExplorerIcon: React.FC<{ size: any }> = ({ size }) => (
   <Icon
     w={size === "xs" ? 3 : size === "sm" ? 4 : 5}
     h={size === "xs" ? 3 : size === "sm" ? 4 : 5}
@@ -173,7 +177,7 @@ const SolanaExplorerIcon: React.FC<{size: any}> = ({ size }) => (
   </Icon>
 );
 
-const SolanaFmIcon: React.FC<{size: any}> = ({ size }) => {
+const SolanaFmIcon: React.FC<{ size: any }> = ({ size }) => {
   const fillColour = useColorModeValue("black", "white");
 
   return (
@@ -211,7 +215,7 @@ const SolanaFmIcon: React.FC<{size: any}> = ({ size }) => {
   );
 };
 
-const SolanaBeachIcon: React.FC<{size: any}> = ({ size }) => (
+const SolanaBeachIcon: React.FC<{ size: any }> = ({ size }) => (
   <Icon
     w={size === "xs" ? 3 : size === "sm" ? 4 : 5}
     h={size === "xs" ? 3 : size === "sm" ? 4 : 5}

--- a/src/components/common/ExplorerButton.tsx
+++ b/src/components/common/ExplorerButton.tsx
@@ -27,7 +27,7 @@ const explorerOpts: Record<Exclude<Explorer, "none">,
   }> = {
   solana: {
     label: "Open in Solana Explorer",
-    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "local"],
+    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "custom"],
     url: (valueType, value, rpcEndpoint) =>
       `https://explorer.solana.com/${
         valueType === "account" ? "address" : valueType
@@ -37,7 +37,7 @@ const explorerOpts: Record<Exclude<Explorer, "none">,
   },
   solanafm: {
     label: "Open in SolanaFM",
-    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "local"],
+    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "custom"],
     url: (valueType, value, rpcEndpoint) =>
       `https://solana.fm/${
         valueType === "account" ? "address" : valueType
@@ -65,7 +65,7 @@ const explorerOpts: Record<Exclude<Explorer, "none">,
   },
   solscan: {
     label: "Open in Solscan",
-    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "local"],
+    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "custom"],
     url: (valueType, value, rpcEndpoint) =>
       `https://solscan.io/${valueType}/${value}?cluster=${
         rpcEndpoint.custom ? "custom" : rpcEndpoint.network

--- a/src/components/common/ExplorerButton.tsx
+++ b/src/components/common/ExplorerButton.tsx
@@ -15,8 +15,7 @@ import { Explorer } from "../../types/state";
 
 export type AddressType = "tx" | "account";
 
-const explorerOpts: Record<
-  Exclude<Explorer, "none">,
+const explorerOpts: Record<Exclude<Explorer, "none">,
   {
     label: string;
     supportedNetworks: INetwork[];
@@ -25,15 +24,16 @@ const explorerOpts: Record<
       value: string,
       rpcEndpoint: IRpcEndpoint
     ) => string;
-  }
-> = {
+  }> = {
   solana: {
     label: "Open in Solana Explorer",
-    supportedNetworks: ["devnet", "testnet", "mainnet-beta"],
+    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "local"],
     url: (valueType, value, rpcEndpoint) =>
       `https://explorer.solana.com/${
         valueType === "account" ? "address" : valueType
-      }/${value}?cluster=${rpcEndpoint.network}`,
+      }/${value}?cluster=${
+        rpcEndpoint.custom ? "custom" : rpcEndpoint.network
+      }${rpcEndpoint.custom ? "&customUrl=" + rpcEndpoint.url : ""}`,
   },
   solanafm: {
     label: "Open in SolanaFM",
@@ -43,12 +43,12 @@ const explorerOpts: Record<
         valueType === "account" ? "address" : valueType
       }/${value}?cluster=${
         rpcEndpoint.custom
-          ? rpcEndpoint.custom
+          ? rpcEndpoint.url
           : rpcEndpoint.network === "devnet"
-          ? "devnet-qn1"
-          : rpcEndpoint.network === "testnet"
-          ? "testnet-qn1"
-          : "mainnet-qn1"
+            ? "devnet-qn1"
+            : rpcEndpoint.network === "testnet"
+              ? "testnet-qn1"
+              : "mainnet-qn1"
       }`,
   },
   solanaBeach: {
@@ -73,13 +73,11 @@ const explorerOpts: Record<
   },
 };
 
-export const ExplorerButton: React.FC<
-  {
-    value: string;
-    valueType: AddressType;
-    rpcEndpoint: IRpcEndpoint;
-  } & Omit<ButtonProps, "aria-label">
-> = ({
+export const ExplorerButton: React.FC<{
+  value: string;
+  valueType: AddressType;
+  rpcEndpoint: IRpcEndpoint;
+} & Omit<ButtonProps, "aria-label">> = ({
   value,
   valueType,
   rpcEndpoint,
@@ -137,7 +135,7 @@ export const ExplorerButton: React.FC<
   );
 };
 
-const SolscanIcon: React.FC<{ size: any }> = ({ size }) => (
+const SolscanIcon: React.FC<{size: any}> = ({ size }) => (
   <Icon
     w={size === "xs" ? 3 : size === "sm" ? 4 : 5}
     h={size === "xs" ? 3 : size === "sm" ? 4 : 5}
@@ -156,7 +154,7 @@ const SolscanIcon: React.FC<{ size: any }> = ({ size }) => (
   </Icon>
 );
 
-const SolanaExplorerIcon: React.FC<{ size: any }> = ({ size }) => (
+const SolanaExplorerIcon: React.FC<{size: any}> = ({ size }) => (
   <Icon
     w={size === "xs" ? 3 : size === "sm" ? 4 : 5}
     h={size === "xs" ? 3 : size === "sm" ? 4 : 5}
@@ -175,7 +173,7 @@ const SolanaExplorerIcon: React.FC<{ size: any }> = ({ size }) => (
   </Icon>
 );
 
-const SolanaFmIcon: React.FC<{ size: any }> = ({ size }) => {
+const SolanaFmIcon: React.FC<{size: any}> = ({ size }) => {
   const fillColour = useColorModeValue("black", "white");
 
   return (
@@ -213,7 +211,7 @@ const SolanaFmIcon: React.FC<{ size: any }> = ({ size }) => {
   );
 };
 
-const SolanaBeachIcon: React.FC<{ size: any }> = ({ size }) => (
+const SolanaBeachIcon: React.FC<{size: any}> = ({ size }) => (
   <Icon
     w={size === "xs" ? 3 : size === "sm" ? 4 : 5}
     h={size === "xs" ? 3 : size === "sm" ? 4 : 5}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -84,7 +84,6 @@ export const Header: React.FC = () => {
           </Tooltip>
         </Hide> */}
 
-
       <ColorModeSwitcher justifySelf="flex-end" />
 
       <DarkMode>

--- a/src/components/options/fields/RpcEndpointOption.tsx
+++ b/src/components/options/fields/RpcEndpointOption.tsx
@@ -47,8 +47,11 @@ export const RpcEndpointOption: React.FC<IRpcEndpoint> = ({
   const [notValidatedUrl, setNotValidatedUrl] = useState(url);
   const setUrl = (url: string) => {
     if (!isValidUrl(url)) return;
+
     set((state) => {
-      state.appOptions.rpcEndpoints.map[id].url = url;
+      if (!Object.values(state.appOptions.rpcEndpoints.map).map(element => element.url).includes(url)) {
+        state.appOptions.rpcEndpoints.map[id].url = url;
+      }
     });
   };
 

--- a/src/components/options/fields/RpcEndpointOption.tsx
+++ b/src/components/options/fields/RpcEndpointOption.tsx
@@ -1,4 +1,4 @@
-import { DeleteIcon } from "@chakra-ui/icons";
+import { DeleteIcon, DragHandleIcon } from "@chakra-ui/icons";
 import {
   Flex,
   Grid,
@@ -9,12 +9,13 @@ import {
   Tooltip,
 } from "@chakra-ui/react";
 import { WritableDraft } from "immer/dist/internal";
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import { FaEye, FaEyeSlash } from "react-icons/fa";
 import { usePersistentStore } from "../../../hooks/usePersistentStore";
 import { INetwork, IRpcEndpoint } from "../../../types/internal";
 import { removeFrom } from "../../../utils/sortable";
-import { DragHandle } from "../../common/DragHandle";
+import { SortableItemContext } from "../../common/Sortable";
+import { RPC_NETWORK_OPTIONS } from "../../../utils/state";
 
 const isValidUrl = (url: string) => {
   try {
@@ -33,6 +34,7 @@ export const RpcEndpointOption: React.FC<IRpcEndpoint> = ({
   custom,
   enabled,
 }) => {
+  const { listeners, attributes } = useContext(SortableItemContext);
   const set = usePersistentStore((state) => state.set);
 
   const updateEndpoint = (fn: (state: WritableDraft<IRpcEndpoint>) => void) => {
@@ -52,7 +54,7 @@ export const RpcEndpointOption: React.FC<IRpcEndpoint> = ({
 
   return (
     <Flex alignItems="center">
-      <DragHandle unlockedProps={{ h: "3", w: "3", mr: "1" }} />
+      <DragHandleIcon h="3" w="3" mr="1" {...attributes} {...listeners} />
 
       <Grid
         p="4"
@@ -78,7 +80,7 @@ export const RpcEndpointOption: React.FC<IRpcEndpoint> = ({
               })
             }
           >
-            {["devnet", "testnet", "mainnet-beta"].map((n) => (
+            {RPC_NETWORK_OPTIONS.map((n) => (
               <option key={n} value={n}>
                 {n}
               </option>

--- a/src/components/options/fields/RpcEndpointOption.tsx
+++ b/src/components/options/fields/RpcEndpointOption.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
 } from "@chakra-ui/react";
 import { WritableDraft } from "immer/dist/internal";
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { FaEye, FaEyeSlash } from "react-icons/fa";
 import { usePersistentStore } from "../../../hooks/usePersistentStore";
 import { INetwork, IRpcEndpoint } from "../../../types/internal";
@@ -51,6 +51,10 @@ export const RpcEndpointOption: React.FC<IRpcEndpoint> = ({
       state.appOptions.rpcEndpoints.map[id].url = url;
     });
   };
+
+  useEffect(() => {
+    setUrl(notValidatedUrl)
+  }, [notValidatedUrl])
 
   return (
     <Flex alignItems="center">
@@ -136,7 +140,6 @@ export const RpcEndpointOption: React.FC<IRpcEndpoint> = ({
           isInvalid={!isValidUrl(notValidatedUrl)}
           onChange={(e) => {
             setNotValidatedUrl(e.target.value);
-            setUrl(notValidatedUrl);
           }}
         />
       </Grid>

--- a/src/components/options/fields/RpcEndpointOption.tsx
+++ b/src/components/options/fields/RpcEndpointOption.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
 } from "@chakra-ui/react";
 import { WritableDraft } from "immer/dist/internal";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 import { FaEye, FaEyeSlash } from "react-icons/fa";
 import { usePersistentStore } from "../../../hooks/usePersistentStore";
 import { INetwork, IRpcEndpoint } from "../../../types/internal";
@@ -45,7 +45,8 @@ export const RpcEndpointOption: React.FC<IRpcEndpoint> = ({
 
   // TODO is this best way?
   const [notValidatedUrl, setNotValidatedUrl] = useState(url);
-  const setUrl = (url: string) => {
+
+  const setUrl = useCallback((url: string) => {
     if (!isValidUrl(url)) return;
 
     set((state) => {
@@ -53,11 +54,11 @@ export const RpcEndpointOption: React.FC<IRpcEndpoint> = ({
         state.appOptions.rpcEndpoints.map[id].url = url;
       }
     });
-  };
+  }, [set, id]);
 
   useEffect(() => {
     setUrl(notValidatedUrl)
-  }, [notValidatedUrl])
+  }, [notValidatedUrl, setUrl])
 
   return (
     <Flex alignItems="center">

--- a/src/components/options/fields/RpcEndpointOption.tsx
+++ b/src/components/options/fields/RpcEndpointOption.tsx
@@ -46,19 +46,26 @@ export const RpcEndpointOption: React.FC<IRpcEndpoint> = ({
   // TODO is this best way?
   const [notValidatedUrl, setNotValidatedUrl] = useState(url);
 
-  const setUrl = useCallback((url: string) => {
-    if (!isValidUrl(url)) return;
+  const setUrl = useCallback(
+    (url: string) => {
+      if (!isValidUrl(url)) return;
 
-    set((state) => {
-      if (!Object.values(state.appOptions.rpcEndpoints.map).map(element => element.url).includes(url)) {
-        state.appOptions.rpcEndpoints.map[id].url = url;
-      }
-    });
-  }, [set, id]);
+      set((state) => {
+        if (
+          !Object.values(state.appOptions.rpcEndpoints.map)
+            .map((element) => element.url)
+            .includes(url)
+        ) {
+          state.appOptions.rpcEndpoints.map[id].url = url;
+        }
+      });
+    },
+    [set, id]
+  );
 
   useEffect(() => {
-    setUrl(notValidatedUrl)
-  }, [notValidatedUrl, setUrl])
+    setUrl(notValidatedUrl);
+  }, [notValidatedUrl, setUrl]);
 
   return (
     <Flex alignItems="center">

--- a/src/mappers/external-to-internal.ts
+++ b/src/mappers/external-to-internal.ts
@@ -48,22 +48,22 @@ export const mapIInstructionExtToIInstruction = ({
       format: data.format,
       raw: {
         content: data.format === "raw" ? (data.value as string) : "",
-        encoding: "bs58"
+        encoding: "bs58",
       },
       borsh: mapToSortableCollection(
         data.format === "borsh"
           ? (data.value as IInstrctionDataFieldExt[]).map((v) => ({
-            id: uuid(),
-            ...v,
-          }))
+              id: uuid(),
+              ...v,
+            }))
           : []
       ),
       bufferLayout: mapToSortableCollection(
         data.format === "bufferLayout"
           ? (data.value as IInstrctionDataFieldExt[]).map((v) => ({
-            id: uuid(),
-            ...v,
-          }))
+              id: uuid(),
+              ...v,
+            }))
           : []
       ),
     },

--- a/src/mappers/external-to-internal.ts
+++ b/src/mappers/external-to-internal.ts
@@ -46,22 +46,24 @@ export const mapIInstructionExtToIInstruction = ({
     accounts: mapToSortableCollection(accounts.map(mpaIAccountExtToIAccount)),
     data: {
       format: data.format,
-      raw: data.format === "raw" ? (data.value as string) : "",
-      isHex: false,
+      raw: {
+        content: data.format === "raw" ? (data.value as string) : "",
+        encoding: "bs58"
+      },
       borsh: mapToSortableCollection(
         data.format === "borsh"
           ? (data.value as IInstrctionDataFieldExt[]).map((v) => ({
-              id: uuid(),
-              ...v,
-            }))
+            id: uuid(),
+            ...v,
+          }))
           : []
       ),
       bufferLayout: mapToSortableCollection(
         data.format === "bufferLayout"
           ? (data.value as IInstrctionDataFieldExt[]).map((v) => ({
-              id: uuid(),
-              ...v,
-            }))
+            id: uuid(),
+            ...v,
+          }))
           : []
       ),
     },

--- a/src/mappers/external-to-internal.ts
+++ b/src/mappers/external-to-internal.ts
@@ -47,6 +47,7 @@ export const mapIInstructionExtToIInstruction = ({
     data: {
       format: data.format,
       raw: data.format === "raw" ? (data.value as string) : "",
+      isHex: false,
       borsh: mapToSortableCollection(
         data.format === "borsh"
           ? (data.value as IInstrctionDataFieldExt[]).map((v) => ({

--- a/src/mappers/internal-to-external.ts
+++ b/src/mappers/internal-to-external.ts
@@ -9,6 +9,7 @@ import {
   ITransaction,
 } from "../types/internal";
 import { toSortedArray } from "../utils/sortable";
+import bs58 from "bs58";
 
 const mapIAccountToIAccountExt = ({
   name,
@@ -48,8 +49,10 @@ export const mapITransactionToTransactionExt = ({
           data.format === "borsh"
             ? toSortedArray(data.borsh).map(mapToIInstrctionDataFieldExt)
             : data.format === "bufferLayout"
-            ? toSortedArray(data.bufferLayout).map(mapToIInstrctionDataFieldExt)
-            : data.raw,
+              ? toSortedArray(data.bufferLayout).map(mapToIInstrctionDataFieldExt)
+              : data.raw.encoding === "hex"
+                ? bs58.encode(Buffer.from(data.raw.content, 'hex'))
+                : data.raw.content,
       },
       anchorMethod,
       anchorAccounts: anchorAccounts?.map(mapIAccountToIAccountExt),

--- a/src/mappers/internal-to-external.ts
+++ b/src/mappers/internal-to-external.ts
@@ -49,10 +49,10 @@ export const mapITransactionToTransactionExt = ({
           data.format === "borsh"
             ? toSortedArray(data.borsh).map(mapToIInstrctionDataFieldExt)
             : data.format === "bufferLayout"
-              ? toSortedArray(data.bufferLayout).map(mapToIInstrctionDataFieldExt)
-              : data.raw.encoding === "hex"
-                ? bs58.encode(Buffer.from(data.raw.content, 'hex'))
-                : data.raw.content,
+            ? toSortedArray(data.bufferLayout).map(mapToIInstrctionDataFieldExt)
+            : data.raw.encoding === "hex"
+            ? bs58.encode(Buffer.from(data.raw.content, "hex"))
+            : data.raw.content,
       },
       anchorMethod,
       anchorAccounts: anchorAccounts?.map(mapIAccountToIAccountExt),

--- a/src/mappers/internal-to-web3js.ts
+++ b/src/mappers/internal-to-web3js.ts
@@ -33,7 +33,11 @@ export const mapITransactionToWeb3Transaction = ({
             toSortedArray(data.bufferLayout)
           );
         } else if (data.format === "raw" && data.raw) {
-          buffer = Buffer.from(bs58.decode(data.raw));
+          if (data.isHex) {
+            buffer = Buffer.from(data.raw, 'hex');
+          } else {
+            buffer = Buffer.from(bs58.decode(data.raw));
+          }
         }
       } catch (err) {
         const message = Object.getOwnPropertyNames(err).includes("message")

--- a/src/mappers/internal-to-web3js.ts
+++ b/src/mappers/internal-to-web3js.ts
@@ -8,6 +8,7 @@ import { BufferLayoutCoder } from "../coders/buffer-layout";
 import { ITransaction } from "../types/internal";
 import { toSortedArray } from "../utils/sortable";
 import { anchorMethodSighash } from "../utils/web3js";
+import bs58 from "bs58";
 
 export const mapITransactionToWeb3Transaction = ({
   instructions,
@@ -31,7 +32,7 @@ export const mapITransactionToWeb3Transaction = ({
           toSortedArray(data.bufferLayout)
         );
       } else if (data.format === "raw" && data.raw) {
-        buffer = Buffer.from(data.raw);
+        buffer = Buffer.from(bs58.decode(data.raw));
       }
 
       // accounts

--- a/src/mappers/internal-to-web3js.ts
+++ b/src/mappers/internal-to-web3js.ts
@@ -16,7 +16,10 @@ export const mapITransactionToWeb3Transaction = ({
   const transaction = new Transaction();
 
   toSortedArray(instructions).forEach(
-    ({ programId, accounts, data, disabled, anchorMethod, anchorAccounts }, index) => {
+    (
+      { programId, accounts, data, disabled, anchorMethod, anchorAccounts },
+      index
+    ) => {
       if (disabled) return;
 
       // handle instruction data
@@ -34,16 +37,18 @@ export const mapITransactionToWeb3Transaction = ({
           );
         } else if (data.format === "raw" && data.raw.content) {
           if (data.raw.encoding === "hex") {
-            buffer = Buffer.from(data.raw.content, 'hex');
+            buffer = Buffer.from(data.raw.content, "hex");
           } else {
             buffer = Buffer.from(bs58.decode(data.raw.content));
           }
         }
       } catch (err) {
         const message = Object.getOwnPropertyNames(err).includes("message")
-          ? (err as {message: string}).message
+          ? (err as { message: string }).message
           : JSON.stringify(err);
-        throw new Error(`Error at Instruction #${index + 1}: ${message} in Data`)
+        throw new Error(
+          `Error at Instruction #${index + 1}: ${message} in Data`
+        );
       }
 
       // accounts
@@ -52,13 +57,19 @@ export const mapITransactionToWeb3Transaction = ({
         .map(({ pubkey, isWritable, isSigner }, keyIdx) => ({
           pubkey: (() => {
             if (isValidPublicKey(pubkey)) {
-              return new PublicKey(pubkey)
+              return new PublicKey(pubkey);
             } else {
-              throw new Error(`Error at Instruction #${index + 1}: Invalid public key input ${pubkey} in Accounts #${keyIdx + 1}`)
+              throw new Error(
+                `Error at Instruction #${
+                  index + 1
+                }: Invalid public key input ${pubkey} in Accounts #${
+                  keyIdx + 1
+                }`
+              );
             }
           })(),
           isWritable,
-          isSigner
+          isSigner,
         }));
 
       // add transaction
@@ -66,16 +77,19 @@ export const mapITransactionToWeb3Transaction = ({
         new TransactionInstruction({
           programId: (() => {
             if (isValidPublicKey(programId)) {
-              return new PublicKey(programId)
+              return new PublicKey(programId);
             } else {
-              throw new Error(`Error at Instruction #${index + 1}: Invalid program id ${programId}`)
+              throw new Error(
+                `Error at Instruction #${
+                  index + 1
+                }: Invalid program id ${programId}`
+              );
             }
           })(),
           keys,
           data: buffer,
         })
       );
-
     }
   );
 

--- a/src/mappers/web3js-to-internal.ts
+++ b/src/mappers/web3js-to-internal.ts
@@ -26,7 +26,7 @@ export const mapWeb3TransactionError = (err: any): string => {
     const errObject = err as Record<string, any>;
     if (errObject?.InstructionError) {
       const [index, errorCode] = errObject.InstructionError;
-      error = `Error at Instruction ${index}: ${JSON.stringify(errorCode)}`;
+      error = `Error at Instruction #${index + 1}: ${JSON.stringify(errorCode)}`;
     }
   }
 

--- a/src/mappers/web3js-to-internal.ts
+++ b/src/mappers/web3js-to-internal.ts
@@ -26,7 +26,9 @@ export const mapWeb3TransactionError = (err: any): string => {
     const errObject = err as Record<string, any>;
     if (errObject?.InstructionError) {
       const [index, errorCode] = errObject.InstructionError;
-      error = `Error at Instruction #${index + 1}: ${JSON.stringify(errorCode)}`;
+      error = `Error at Instruction #${index + 1}: ${JSON.stringify(
+        errorCode
+      )}`;
     }
   }
 

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,15 +1,15 @@
-import { ReportHandler } from "web-vitals"
+import { ReportHandler } from "web-vitals";
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     import("web-vitals").then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry)
-      getFID(onPerfEntry)
-      getFCP(onPerfEntry)
-      getLCP(onPerfEntry)
-      getTTFB(onPerfEntry)
-    })
+      getCLS(onPerfEntry);
+      getFID(onPerfEntry);
+      getFCP(onPerfEntry);
+      getLCP(onPerfEntry);
+      getTTFB(onPerfEntry);
+    });
   }
-}
+};
 
-export default reportWebVitals
+export default reportWebVitals;

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -16,46 +16,46 @@ const isLocalhost = Boolean(
     window.location.hostname === "[::1]" ||
     // 127.0.0.0/8 are considered localhost for IPv4.
     window.location.hostname.match(
-      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/,
-    ),
-)
+      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
+    )
+);
 
 type Config = {
-  onSuccess?: (registration: ServiceWorkerRegistration) => void
-  onUpdate?: (registration: ServiceWorkerRegistration) => void
-}
+  onSuccess?: (registration: ServiceWorkerRegistration) => void;
+  onUpdate?: (registration: ServiceWorkerRegistration) => void;
+};
 
 export function register(config?: Config) {
   if (process.env.NODE_ENV === "production" && "serviceWorker" in navigator) {
     // The URL constructor is available in all browsers that support SW.
-    const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href)
+    const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
     if (publicUrl.origin !== window.location.origin) {
       // Our service worker won't work if PUBLIC_URL is on a different origin
       // from what our page is served on. This might happen if a CDN is used to
       // serve assets; see https://github.com/facebook/create-react-app/issues/2374
-      return
+      return;
     }
 
     window.addEventListener("load", () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`
+      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
 
       if (isLocalhost) {
         // This is running on localhost. Let's check if a service worker still exists or not.
-        checkValidServiceWorker(swUrl, config)
+        checkValidServiceWorker(swUrl, config);
 
         // Add some additional logging to localhost, pointing developers to the
         // service worker/PWA documentation.
         navigator.serviceWorker.ready.then(() => {
           console.log(
             "This web app is being served cache-first by a service " +
-              "worker. To learn more, visit https://cra.link/PWA",
-          )
-        })
+              "worker. To learn more, visit https://cra.link/PWA"
+          );
+        });
       } else {
         // Is not localhost. Just register service worker
-        registerValidSW(swUrl, config)
+        registerValidSW(swUrl, config);
       }
-    })
+    });
   }
 }
 
@@ -64,9 +64,9 @@ function registerValidSW(swUrl: string, config?: Config) {
     .register(swUrl)
     .then((registration) => {
       registration.onupdatefound = () => {
-        const installingWorker = registration.installing
+        const installingWorker = registration.installing;
         if (installingWorker == null) {
-          return
+          return;
         }
         installingWorker.onstatechange = () => {
           if (installingWorker.state === "installed") {
@@ -76,31 +76,31 @@ function registerValidSW(swUrl: string, config?: Config) {
               // content until all client tabs are closed.
               console.log(
                 "New content is available and will be used when all " +
-                  "tabs for this page are closed. See https://cra.link/PWA.",
-              )
+                  "tabs for this page are closed. See https://cra.link/PWA."
+              );
 
               // Execute callback
               if (config && config.onUpdate) {
-                config.onUpdate(registration)
+                config.onUpdate(registration);
               }
             } else {
               // At this point, everything has been precached.
               // It is the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log("Content is cached for offline use.")
+              console.log("Content is cached for offline use.");
 
               // Execute callback
               if (config && config.onSuccess) {
-                config.onSuccess(registration)
+                config.onSuccess(registration);
               }
             }
           }
-        }
-      }
+        };
+      };
     })
     .catch((error) => {
-      console.error("Error during service worker registration:", error)
-    })
+      console.error("Error during service worker registration:", error);
+    });
 }
 
 function checkValidServiceWorker(swUrl: string, config?: Config) {
@@ -110,7 +110,7 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
   })
     .then((response) => {
       // Ensure service worker exists, and that we really are getting a JS file.
-      const contentType = response.headers.get("content-type")
+      const contentType = response.headers.get("content-type");
       if (
         response.status === 404 ||
         (contentType != null && contentType.indexOf("javascript") === -1)
@@ -118,29 +118,29 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
         // No service worker found. Probably a different app. Reload the page.
         navigator.serviceWorker.ready.then((registration) => {
           registration.unregister().then(() => {
-            window.location.reload()
-          })
-        })
+            window.location.reload();
+          });
+        });
       } else {
         // Service worker found. Proceed as normal.
-        registerValidSW(swUrl, config)
+        registerValidSW(swUrl, config);
       }
     })
     .catch(() => {
       console.log(
-        "No internet connection found. App is running in offline mode.",
-      )
-    })
+        "No internet connection found. App is running in offline mode."
+      );
+    });
 }
 
 export function unregister() {
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.ready
       .then((registration) => {
-        registration.unregister()
+        registration.unregister();
       })
       .catch((error) => {
-        console.error(error.message)
-      })
+        console.error(error.message);
+      });
   }
 }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import "@testing-library/jest-dom"
+import "@testing-library/jest-dom";

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -44,10 +44,14 @@ export interface IInstrctionDataField {
 
 export type DataFormat = "raw" | "bufferLayout" | "borsh";
 
+export interface IRaw {
+  content: string;
+  encoding: "hex" | "bs58"
+}
+
 export interface IInstructionData {
   format: DataFormat;
-  raw: string;
-  isHex: boolean;
+  raw: IRaw;
   borsh: SortableCollection<IInstrctionDataField>;
   bufferLayout: SortableCollection<IInstrctionDataField>;
 }

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -47,6 +47,7 @@ export type DataFormat = "raw" | "bufferLayout" | "borsh";
 export interface IInstructionData {
   format: DataFormat;
   raw: string;
+  isHex: boolean;
   borsh: SortableCollection<IInstrctionDataField>;
   bufferLayout: SortableCollection<IInstrctionDataField>;
 }

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -75,7 +75,7 @@ export interface IInstruction {
   readonly expanded: boolean;
 }
 
-export type INetwork = "local" | "devnet" | "testnet" | "mainnet-beta";
+export type INetwork = "custom" | "devnet" | "testnet" | "mainnet-beta";
 
 export interface IRpcEndpoint {
   id: IID;

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -46,7 +46,7 @@ export type DataFormat = "raw" | "bufferLayout" | "borsh";
 
 export interface IRaw {
   content: string;
-  encoding: "hex" | "bs58"
+  encoding: "hex" | "bs58";
 }
 
 export interface IInstructionData {

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -37,7 +37,7 @@ export const EMPTY_INSTRUCTION_DATA: IInstructionData = {
   format: "raw",
   raw: {
     content: "",
-    encoding: "bs58"
+    encoding: "bs58",
   },
   borsh: toSortableCollection([]),
   bufferLayout: toSortableCollection([]),

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -35,8 +35,10 @@ export const newAccount = (): IAccount => ({
 
 export const EMPTY_INSTRUCTION_DATA: IInstructionData = {
   format: "raw",
-  raw: "",
-  isHex: false,
+  raw: {
+    content: "",
+    encoding: "bs58"
+  },
   borsh: toSortableCollection([]),
   bufferLayout: toSortableCollection([]),
 };

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -36,6 +36,7 @@ export const newAccount = (): IAccount => ({
 export const EMPTY_INSTRUCTION_DATA: IInstructionData = {
   format: "raw",
   raw: "",
+  isHex: false,
   borsh: toSortableCollection([]),
   bufferLayout: toSortableCollection([]),
 };

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -16,6 +16,8 @@ import {
 import { newAccount, newInstruction } from "./internal";
 import { toSortableCollection } from "./sortable";
 
+export const RPC_NETWORK_OPTIONS: string[] = ["devnet", "testnet", "mainnet-beta", "custom"];
+
 export const DEFAULT_RPC_ENDPOINTS: IRpcEndpoint[] = [
   {
     id: uuid(),

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -16,7 +16,12 @@ import {
 import { newAccount, newInstruction } from "./internal";
 import { toSortableCollection } from "./sortable";
 
-export const RPC_NETWORK_OPTIONS: string[] = ["devnet", "testnet", "mainnet-beta", "custom"];
+export const RPC_NETWORK_OPTIONS: string[] = [
+  "devnet",
+  "testnet",
+  "mainnet-beta",
+  "custom",
+];
 
 export const DEFAULT_RPC_ENDPOINTS: IRpcEndpoint[] = [
   {
@@ -106,8 +111,7 @@ export const DEFAULT_SESSION_STATE_WITH_UNDO: SessionStateWithUndo = {
   transaction: DEFAULT_TRANSACTION,
   rpcEndpoint: DEFAULT_RPC_ENDPOINTS[0],
   keypairs: {},
-  set: () => {
-  }, // set by the hook
+  set: () => {}, // set by the hook
 };
 
 export const DEFAULT_SESSION_STATE_WITHOUT_UNDO: SessionStateWithoutUndo = {
@@ -119,14 +123,12 @@ export const DEFAULT_SESSION_STATE_WITHOUT_UNDO: SessionStateWithoutUndo = {
     infoOpen: false,
   },
   import: DEFAULT_IMPORT,
-  set: () => {
-  }, // set by the hook
+  set: () => {}, // set by the hook
 };
 
 export const DEFAULT_PERSISTENT_STATE: PersistentState = {
   transactionOptions: DEFAUT_TRANSACTION_OPTIONS,
   appOptions: DEFAULT_APP_OPTIONS,
   firstTime: true,
-  set: () => {
-  }, // set by the hook
+  set: () => {}, // set by the hook
 };

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -51,8 +51,8 @@ export const DEFAULT_RPC_ENDPOINTS: IRpcEndpoint[] = [
   },
   {
     id: uuid(),
-    provider: "You",
-    network: "local",
+    provider: "Localhost",
+    network: "custom",
     url: "http://127.0.0.1:8899",
     enabled: true,
     custom: true,
@@ -104,7 +104,8 @@ export const DEFAULT_SESSION_STATE_WITH_UNDO: SessionStateWithUndo = {
   transaction: DEFAULT_TRANSACTION,
   rpcEndpoint: DEFAULT_RPC_ENDPOINTS[0],
   keypairs: {},
-  set: () => {}, // set by the hook
+  set: () => {
+  }, // set by the hook
 };
 
 export const DEFAULT_SESSION_STATE_WITHOUT_UNDO: SessionStateWithoutUndo = {
@@ -116,12 +117,14 @@ export const DEFAULT_SESSION_STATE_WITHOUT_UNDO: SessionStateWithoutUndo = {
     infoOpen: false,
   },
   import: DEFAULT_IMPORT,
-  set: () => {}, // set by the hook
+  set: () => {
+  }, // set by the hook
 };
 
 export const DEFAULT_PERSISTENT_STATE: PersistentState = {
   transactionOptions: DEFAUT_TRANSACTION_OPTIONS,
   appOptions: DEFAULT_APP_OPTIONS,
   firstTime: true,
-  set: () => {}, // set by the hook
+  set: () => {
+  }, // set by the hook
 };


### PR DESCRIPTION
* Fix invalid instruction data when using raw data to send a transaction
* Include instruction index, instruction account index in error message when mapping internal transaction to web3 transaction
* Add switch button to encode and decode raw instruction data between base58 and hex
* Fix explorer url when using custom rpc network
* Redefine INetwork by replacing "local" with "custom"
* Add "custom" option to rcp network dropdown
* Fix endpoint url is not updating when adding custom rpc
* Avoid adding duplicate endpoint url