### PR TITLE
Add a switch button to encode and decode raw instruction data between base58 and hex, fix explorer with custom rpc, fix adding custom rpc endpoint

### DIFF
--- a/src/components/client/TransactionHeader.tsx
+++ b/src/components/client/TransactionHeader.tsx
@@ -107,7 +107,7 @@ export const TransactionHeader: React.FC<{
           label={
             walletPublicKey
               ? "Run Transaction"
-              : "Please connect a wallet to contiune"
+              : "Please connect a wallet to continue"
           }
         >
           <Button

--- a/src/components/client/data/RawData.tsx
+++ b/src/components/client/data/RawData.tsx
@@ -1,21 +1,73 @@
-import { Textarea } from "@chakra-ui/react";
+import { Box, Icon, Textarea, useToast } from "@chakra-ui/react";
 import React from "react";
 import { useInstruction } from "../../../hooks/useInstruction";
+import { IRaw } from "../../../types/internal";
+import { ToggleIconButton } from "../../common/ToggleIconButton";
+import { HiOutlineSwitchHorizontal } from "react-icons/hi";
+import bs58 from "bs58";
 
-export const RawData: React.FC<{ data: string }> = ({ data }) => {
+export const RawData: React.FC<{ data: IRaw }> = ({ data }) => {
   const { update } = useInstruction();
 
+  const toast = useToast();
+
+  const onToggle = () => {
+    update((state) => {
+      if (data.encoding === "hex") {
+        state.data.raw.content = bs58.encode(Buffer.from(data.content, "hex"));
+        state.data.raw.encoding = "bs58";
+      } else {
+        try {
+          state.data.raw.content = Buffer.from(
+            bs58.decode(state.data.raw.content)
+          ).toString("hex");
+          state.data.raw.encoding = "hex";
+        } catch (e) {
+          // it is not a valid base58 string
+          toast({
+            title: "Invalid string",
+            description: "This is not a valid base58 encoded string.",
+            status: "error",
+            isClosable: true,
+            duration: 30_000,
+          });
+        }
+      }
+    });
+  };
+
   return (
-    <Textarea
-      flex="1"
-      fontFamily="mono"
-      placeholder="Instruction data"
-      value={data}
-      onChange={(e) => {
-        update((state) => {
-          state.data.raw = e.target.value;
-        });
-      }}
-    />
+    <Box display="flex">
+      <Textarea
+        flex="1"
+        fontFamily="mono"
+        placeholder={
+          data.encoding === "hex"
+            ? "Instruction data (hex)"
+            : "Instruction data (base58 encoded)"
+        }
+        value={data.content}
+        onChange={(e) => {
+          update((state) => {
+            state.data.raw.content = e.target.value;
+          });
+        }}
+      />
+
+      <Box ml="auto" mt="auto">
+        <ToggleIconButton
+          ml="1"
+          size="sm"
+          label={
+            data.encoding === "hex"
+              ? "Click to use encoded data"
+              : "Click to use hex data"
+          }
+          icon={<Icon as={HiOutlineSwitchHorizontal} />}
+          toggled={data.encoding !== "hex"}
+          onToggle={onToggle}
+        />
+      </Box>
+    </Box>
   );
 };

--- a/src/components/common/ExplorerButton.tsx
+++ b/src/components/common/ExplorerButton.tsx
@@ -29,7 +29,7 @@ const explorerOpts: Record<
 > = {
   solana: {
     label: "Open in Solana Explorer",
-    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "local"],
+    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "custom"],
     url: (valueType, value, rpcEndpoint) =>
       `https://explorer.solana.com/${
         valueType === "account" ? "address" : valueType
@@ -39,7 +39,7 @@ const explorerOpts: Record<
   },
   solanafm: {
     label: "Open in SolanaFM",
-    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "local"],
+    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "custom"],
     url: (valueType, value, rpcEndpoint) =>
       `https://solana.fm/${
         valueType === "account" ? "address" : valueType
@@ -67,7 +67,7 @@ const explorerOpts: Record<
   },
   solscan: {
     label: "Open in Solscan",
-    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "local"],
+    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "custom"],
     url: (valueType, value, rpcEndpoint) =>
       `https://solscan.io/${valueType}/${value}?cluster=${
         rpcEndpoint.custom ? "custom" : rpcEndpoint.network

--- a/src/components/common/ExplorerButton.tsx
+++ b/src/components/common/ExplorerButton.tsx
@@ -29,11 +29,13 @@ const explorerOpts: Record<
 > = {
   solana: {
     label: "Open in Solana Explorer",
-    supportedNetworks: ["devnet", "testnet", "mainnet-beta"],
+    supportedNetworks: ["devnet", "testnet", "mainnet-beta", "local"],
     url: (valueType, value, rpcEndpoint) =>
       `https://explorer.solana.com/${
         valueType === "account" ? "address" : valueType
-      }/${value}?cluster=${rpcEndpoint.network}`,
+      }/${value}?cluster=${
+        rpcEndpoint.custom ? "custom" : rpcEndpoint.network
+      }${rpcEndpoint.custom ? "&customUrl=" + rpcEndpoint.url : ""}`,
   },
   solanafm: {
     label: "Open in SolanaFM",
@@ -43,7 +45,7 @@ const explorerOpts: Record<
         valueType === "account" ? "address" : valueType
       }/${value}?cluster=${
         rpcEndpoint.custom
-          ? rpcEndpoint.custom
+          ? rpcEndpoint.url
           : rpcEndpoint.network === "devnet"
           ? "devnet-qn1"
           : rpcEndpoint.network === "testnet"

--- a/src/components/header/Examples.tsx
+++ b/src/components/header/Examples.tsx
@@ -55,7 +55,7 @@ export const Example: React.FC = () => {
           label={
             walletPublicKey
               ? "Load an example transaction"
-              : "Please connect a wallet to contiune"
+              : "Please connect a wallet to continue"
           }
         >
           <MenuButton

--- a/src/components/options/fields/RpcEndpointOption.tsx
+++ b/src/components/options/fields/RpcEndpointOption.tsx
@@ -14,6 +14,7 @@ import { FaEye, FaEyeSlash } from "react-icons/fa";
 import { usePersistentStore } from "../../../hooks/usePersistentStore";
 import { INetwork, IRpcEndpoint } from "../../../types/internal";
 import { removeFrom } from "../../../utils/sortable";
+import { RPC_NETWORK_OPTIONS } from "../../../utils/state";
 import { DragHandle } from "../../common/DragHandle";
 
 const isValidUrl = (url: string) => {
@@ -78,7 +79,7 @@ export const RpcEndpointOption: React.FC<IRpcEndpoint> = ({
               })
             }
           >
-            {["devnet", "testnet", "mainnet-beta"].map((n) => (
+            {RPC_NETWORK_OPTIONS.map((n) => (
               <option key={n} value={n}>
                 {n}
               </option>

--- a/src/components/options/fields/RpcEndpointOption.tsx
+++ b/src/components/options/fields/RpcEndpointOption.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
 } from "@chakra-ui/react";
 import { WritableDraft } from "immer/dist/internal";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { FaEye, FaEyeSlash } from "react-icons/fa";
 import { usePersistentStore } from "../../../hooks/usePersistentStore";
 import { INetwork, IRpcEndpoint } from "../../../types/internal";
@@ -44,12 +44,23 @@ export const RpcEndpointOption: React.FC<IRpcEndpoint> = ({
 
   // TODO is this best way?
   const [notValidatedUrl, setNotValidatedUrl] = useState(url);
-  const setUrl = (url: string) => {
-    if (!isValidUrl(url)) return;
-    set((state) => {
-      state.appOptions.rpcEndpoints.map[id].url = url;
-    });
-  };
+
+  useEffect(() => {
+    const setUrl = (url: string) => {
+      if (!isValidUrl(url)) return;
+
+      set((state) => {
+        if (
+          !Object.values(state.appOptions.rpcEndpoints.map)
+            .map((element) => element.url)
+            .includes(url)
+        ) {
+          state.appOptions.rpcEndpoints.map[id].url = url;
+        }
+      });
+    };
+    setUrl(notValidatedUrl);
+  }, [notValidatedUrl, id, set]);
 
   return (
     <Flex alignItems="center">
@@ -135,7 +146,6 @@ export const RpcEndpointOption: React.FC<IRpcEndpoint> = ({
           isInvalid={!isValidUrl(notValidatedUrl)}
           onChange={(e) => {
             setNotValidatedUrl(e.target.value);
-            setUrl(notValidatedUrl);
           }}
         />
       </Grid>

--- a/src/mappers/external-to-internal.ts
+++ b/src/mappers/external-to-internal.ts
@@ -46,7 +46,10 @@ export const mapIInstructionExtToIInstruction = ({
     accounts: mapToSortableCollection(accounts.map(mpaIAccountExtToIAccount)),
     data: {
       format: data.format,
-      raw: data.format === "raw" ? (data.value as string) : "",
+      raw: {
+        content: data.format === "raw" ? (data.value as string) : "",
+        encoding: "bs58",
+      },
       borsh: mapToSortableCollection(
         data.format === "borsh"
           ? (data.value as IInstrctionDataFieldExt[]).map((v) => ({

--- a/src/mappers/internal-to-external.ts
+++ b/src/mappers/internal-to-external.ts
@@ -9,6 +9,7 @@ import {
   ITransaction,
 } from "../types/internal";
 import { toSortedArray } from "../utils/sortable";
+import bs58 from "bs58";
 
 const mapIAccountToIAccountExt = ({
   name,
@@ -49,7 +50,9 @@ export const mapITransactionToTransactionExt = ({
             ? toSortedArray(data.borsh).map(mapToIInstrctionDataFieldExt)
             : data.format === "bufferLayout"
             ? toSortedArray(data.bufferLayout).map(mapToIInstrctionDataFieldExt)
-            : data.raw,
+            : data.raw.encoding === "hex"
+            ? bs58.encode(Buffer.from(data.raw.content, "hex"))
+            : data.raw.content,
       },
       anchorMethod,
       anchorAccounts: anchorAccounts?.map(mapIAccountToIAccountExt),

--- a/src/mappers/internal-to-web3js.ts
+++ b/src/mappers/internal-to-web3js.ts
@@ -8,6 +8,7 @@ import { BufferLayoutCoder } from "../coders/buffer-layout";
 import { ITransaction } from "../types/internal";
 import { toSortedArray } from "../utils/sortable";
 import { anchorMethodSighash } from "../utils/web3js";
+import bs58 from "bs58";
 
 export const mapITransactionToWeb3Transaction = ({
   instructions,
@@ -31,7 +32,7 @@ export const mapITransactionToWeb3Transaction = ({
           toSortedArray(data.bufferLayout)
         );
       } else if (data.format === "raw" && data.raw) {
-        buffer = Buffer.from(data.raw);
+        buffer = Buffer.from(bs58.decode(data.raw));
       }
 
       // accounts

--- a/src/mappers/internal-to-web3js.ts
+++ b/src/mappers/internal-to-web3js.ts
@@ -35,8 +35,12 @@ export const mapITransactionToWeb3Transaction = ({
           buffer = new BufferLayoutCoder().encode(
             toSortedArray(data.bufferLayout)
           );
-        } else if (data.format === "raw" && data.raw) {
-          buffer = Buffer.from(bs58.decode(data.raw));
+        } else if (data.format === "raw" && data.raw.content) {
+          if (data.raw.encoding === "hex") {
+            buffer = Buffer.from(data.raw.content, "hex");
+          } else {
+            buffer = Buffer.from(bs58.decode(data.raw.content));
+          }
         }
       } catch (err) {
         const message = Object.getOwnPropertyNames(err).includes("message")

--- a/src/mappers/web3js-to-internal.ts
+++ b/src/mappers/web3js-to-internal.ts
@@ -26,7 +26,9 @@ export const mapWeb3TransactionError = (err: any): string => {
     const errObject = err as Record<string, any>;
     if (errObject?.InstructionError) {
       const [index, errorCode] = errObject.InstructionError;
-      error = `Error at Instruction ${index}: ${JSON.stringify(errorCode)}`;
+      error = `Error at Instruction #${index + 1}: ${JSON.stringify(
+        errorCode
+      )}`;
     }
   }
 

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -75,7 +75,7 @@ export interface IInstruction {
   readonly expanded: boolean;
 }
 
-export type INetwork = "local" | "devnet" | "testnet" | "mainnet-beta";
+export type INetwork = "custom" | "devnet" | "testnet" | "mainnet-beta";
 
 export interface IRpcEndpoint {
   id: IID;

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -44,9 +44,14 @@ export interface IInstrctionDataField {
 
 export type DataFormat = "raw" | "bufferLayout" | "borsh";
 
+export interface IRaw {
+  content: string;
+  encoding: "hex" | "bs58";
+}
+
 export interface IInstructionData {
   format: DataFormat;
-  raw: string;
+  raw: IRaw;
   borsh: SortableCollection<IInstrctionDataField>;
   bufferLayout: SortableCollection<IInstrctionDataField>;
 }

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -35,7 +35,10 @@ export const newAccount = (): IAccount => ({
 
 export const EMPTY_INSTRUCTION_DATA: IInstructionData = {
   format: "raw",
-  raw: "",
+  raw: {
+    content: "",
+    encoding: "bs58",
+  },
   borsh: toSortableCollection([]),
   bufferLayout: toSortableCollection([]),
 };

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -16,6 +16,13 @@ import {
 import { newAccount, newInstruction } from "./internal";
 import { toSortableCollection } from "./sortable";
 
+export const RPC_NETWORK_OPTIONS: string[] = [
+  "devnet",
+  "testnet",
+  "mainnet-beta",
+  "custom",
+];
+
 export const DEFAULT_RPC_ENDPOINTS: IRpcEndpoint[] = [
   {
     id: uuid(),
@@ -51,8 +58,8 @@ export const DEFAULT_RPC_ENDPOINTS: IRpcEndpoint[] = [
   },
   {
     id: uuid(),
-    provider: "You",
-    network: "local",
+    provider: "Localhost",
+    network: "custom",
     url: "http://127.0.0.1:8899",
     enabled: true,
     custom: true,

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -1,6 +1,7 @@
 import { clusterApiUrl } from "@solana/web3.js";
 import { v4 as uuid } from "uuid";
 import {
+  INetwork,
   IRpcEndpoint,
   ITransaction,
   ITransactionOptions,
@@ -16,7 +17,7 @@ import {
 import { newAccount, newInstruction } from "./internal";
 import { toSortableCollection } from "./sortable";
 
-export const RPC_NETWORK_OPTIONS: string[] = [
+export const RPC_NETWORK_OPTIONS: INetwork[] = [
   "devnet",
   "testnet",
   "mainnet-beta",


### PR DESCRIPTION
* Fix invalid instruction data when using raw data to send a transaction
* Include instruction index, instruction account index in error message when mapping internal transaction to web3 transaction
* Add switch button to encode and decode raw instruction data between base58 and hex
* Fix explorer url when using custom rpc network
* Redefine INetwork by replacing "local" with "custom"
* Add "custom" option to rcp network dropdown
* Fix endpoint url is not updating when adding custom rpc
* Avoid adding duplicate endpoint url