### PR TITLE
Radio button for encoding & other minor fixes

### DIFF
--- a/src/components/client/data/RawData.tsx
+++ b/src/components/client/data/RawData.tsx
@@ -22,29 +22,40 @@ export const RawData: React.FC = () => {
   const toast = useToast();
 
   const onChange = (encoding: string) => {
-    if (encoding === "hex") {
+    if (encoding === "bs58") {
+      const encoded = bs58.encode(Buffer.from(content, "hex"));
+
+      if (content.length !== 0 && encoded.length === 0) {
+        toast({
+          title: "Invalid raw data",
+          description: "This is not a valid hexadecimal string.",
+          status: "error",
+          isClosable: true,
+        });
+        return;
+      }
+
       update((state) => {
-        state.data.raw.content = bs58.encode(Buffer.from(content, "hex"));
-        state.data.raw.encoding = "hex";
+        state.data.raw.content = encoded;
+        state.data.raw.encoding = "bs58";
       });
     }
 
-    if (encoding === "bs58") {
+    if (encoding === "hex") {
       try {
         const encoded = Buffer.from(bs58.decode(content)).toString("hex");
         update((state) => {
           state.data.raw.content = encoded;
-          state.data.raw.encoding = "bs58";
+          state.data.raw.encoding = "hex";
         });
       } catch (e) {
-        // it is not a valid base58 string
         toast({
-          title: "Invalid string",
-          description: "This is not a valid base58 encoded string.",
+          title: "Invalid raw data",
+          description: "This is not a valid base 58-encoded string.",
           status: "error",
           isClosable: true,
-          duration: 30_000,
         });
+        return;
       }
     }
   };

--- a/src/components/client/data/RawData.tsx
+++ b/src/components/client/data/RawData.tsx
@@ -1,9 +1,16 @@
-import { Box, Icon, Textarea, useToast } from "@chakra-ui/react";
+import {
+  Flex,
+  Grid,
+  Radio,
+  RadioGroup,
+  Spacer,
+  Stack,
+  Textarea,
+  useToast,
+} from "@chakra-ui/react";
 import bs58 from "bs58";
 import React from "react";
-import { HiOutlineSwitchHorizontal } from "react-icons/hi";
 import { useInstruction } from "../../../hooks/useInstruction";
-import { ToggleIconButton } from "../../common/ToggleIconButton";
 
 export const RawData: React.FC = () => {
   const { useShallowGet, update } = useInstruction();
@@ -14,33 +21,52 @@ export const RawData: React.FC = () => {
 
   const toast = useToast();
 
-  const onToggle = () => {
-    update((state) => {
-      if (encoding === "hex") {
+  const onChange = (encoding: string) => {
+    if (encoding === "hex") {
+      update((state) => {
         state.data.raw.content = bs58.encode(Buffer.from(content, "hex"));
-        state.data.raw.encoding = "bs58";
-      } else {
-        try {
-          state.data.raw.content = Buffer.from(
-            bs58.decode(state.data.raw.content)
-          ).toString("hex");
-          state.data.raw.encoding = "hex";
-        } catch (e) {
-          // it is not a valid base58 string
-          toast({
-            title: "Invalid string",
-            description: "This is not a valid base58 encoded string.",
-            status: "error",
-            isClosable: true,
-            duration: 30_000,
-          });
-        }
+        state.data.raw.encoding = "hex";
+      });
+    }
+
+    if (encoding === "bs58") {
+      try {
+        const encoded = Buffer.from(bs58.decode(content)).toString("hex");
+        update((state) => {
+          state.data.raw.content = encoded;
+          state.data.raw.encoding = "bs58";
+        });
+      } catch (e) {
+        // it is not a valid base58 string
+        toast({
+          title: "Invalid string",
+          description: "This is not a valid base58 encoded string.",
+          status: "error",
+          isClosable: true,
+          duration: 30_000,
+        });
       }
-    });
+    }
   };
 
   return (
-    <Box display="flex">
+    <Grid>
+      <Flex>
+        <Spacer />
+        <RadioGroup
+          size="sm"
+          mb="1"
+          mr="2"
+          value={encoding}
+          onChange={onChange}
+        >
+          <Stack direction="row">
+            <Radio value="bs58">Base 58</Radio>
+            <Radio value="hex">Hex</Radio>
+          </Stack>
+        </RadioGroup>
+      </Flex>
+
       <Textarea
         flex="1"
         fontFamily="mono"
@@ -56,21 +82,6 @@ export const RawData: React.FC = () => {
           });
         }}
       />
-
-      <Box ml="auto" mt="auto">
-        <ToggleIconButton
-          ml="1"
-          size="sm"
-          label={
-            encoding === "hex"
-              ? "Click to use encoded data"
-              : "Click to use hex data"
-          }
-          icon={<Icon as={HiOutlineSwitchHorizontal} />}
-          toggled={encoding !== "hex"}
-          onToggle={onToggle}
-        />
-      </Box>
-    </Box>
+    </Grid>
   );
 };

--- a/src/components/common/ExplorerButton.tsx
+++ b/src/components/common/ExplorerButton.tsx
@@ -97,43 +97,38 @@ export const ExplorerButton: React.FC<
   const opts = explorerOpts[explorer];
   const disabled =
     isDisabled || !opts.supportedNetworks.includes(rpcEndpoint.network);
-
-  const child =
-    variant === "link" ? (
-      children || (
-        <Button variant="link" {...theRest}>
-          {value} <ExternalLinkIcon ml="1" />
-        </Button>
-      )
-    ) : (
-      <IconButton
-        variant="ghost"
-        icon={
-          explorer === "solscan" ? (
-            <SolscanIcon size={size} />
-          ) : explorer === "solanafm" ? (
-            <SolanaFmIcon size={size} />
-          ) : explorer === "solanaBeach" ? (
-            <SolanaBeachIcon size={size} />
-          ) : (
-            <SolanaExplorerIcon size={size} />
-          )
-        }
-        aria-label={opts.label}
-        size={size}
-        isDisabled={disabled}
-        {...theRest}
-      />
-    );
+  const href = !disabled ? opts.url(valueType, value, rpcEndpoint) : undefined;
 
   return (
     <Tooltip label={opts.label} isDisabled={disabled}>
-      {disabled ? (
-        <Link>{child}</Link>
+      {variant === "link" ? (
+        children || (
+          <Button as={Link} variant="link" href={href} isExternal {...theRest}>
+            {value} <ExternalLinkIcon ml="1" />
+          </Button>
+        )
       ) : (
-        <Link href={opts.url(valueType, value, rpcEndpoint)} isExternal>
-          {child}
-        </Link>
+        <IconButton
+          as={Link}
+          variant="ghost"
+          href={href}
+          isExternal
+          icon={
+            explorer === "solscan" ? (
+              <SolscanIcon size={size} />
+            ) : explorer === "solanafm" ? (
+              <SolanaFmIcon size={size} />
+            ) : explorer === "solanaBeach" ? (
+              <SolanaBeachIcon size={size} />
+            ) : (
+              <SolanaExplorerIcon size={size} />
+            )
+          }
+          aria-label={opts.label}
+          size={size}
+          isDisabled={disabled}
+          {...theRest}
+        />
       )}
     </Tooltip>
   );

--- a/src/components/palette/preview/AccountSummary.tsx
+++ b/src/components/palette/preview/AccountSummary.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   Tooltip,
   useColorModeValue,
+  Wrap,
 } from "@chakra-ui/react";
 import React from "react";
 import { IAccountSummary } from "../../../types/preview";
@@ -62,13 +63,15 @@ export const AccountSummary: React.FC<
         </Flex>
       </Tooltip>
 
-      {tags.map(({ label, tooltip, count, colourScheme }, index) => (
-        <Tooltip key={index} label={tooltip}>
-          <Tag mr="1" size="sm" colorScheme={colourScheme}>
-            {label}: {count}
-          </Tag>
-        </Tooltip>
-      ))}
+      <Wrap spacing={1}>
+        {tags.map(({ label, tooltip, count, colourScheme }, index) => (
+          <Tooltip key={index} label={tooltip}>
+            <Tag mr="1" size="sm" colorScheme={colourScheme}>
+              {label}: {count}
+            </Tag>
+          </Tooltip>
+        ))}
+      </Wrap>
     </Flex>
   );
 };

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -77,9 +77,11 @@ export interface IInstrctionDataField {
 
 export type DataFormat = "raw" | "bufferLayout" | "borsh";
 
+export type RawEncoding = "hex" | "bs58";
+
 export interface IRaw {
   content: string;
-  encoding: "hex" | "bs58";
+  encoding: RawEncoding;
 }
 
 export interface IInstructionData {


### PR DESCRIPTION
I changed the encoding to a radio button:

![image](https://user-images.githubusercontent.com/4444588/186271809-6cbe889b-aa29-427b-bdb4-470a10637096.png)

Why?

* More standard
* Smaller profile than a toggle button and yet provides more info
* Toggle is not natural: users can't intuit "toggle on" to means hex or bs58? They are not on-off states.
    * Cannot rely on placeholder as it will disappear once there is content
* I tend to use icon buttons and toggles only when there isn't enough room or too many of the same buttons so labels get annoying

Other changes:

* Account summaries now wrap at tag level, not at text
![image](https://user-images.githubusercontent.com/4444588/186272481-accc9ae9-0c5e-494b-b1d8-fc063090c09f.png)
* If using the keyboard tab, it uses to tab twice on Explorer buttons