### PR TITLE
Disable ATA account types temporarily

### DIFF
--- a/src/components/client/accounts/Account.tsx
+++ b/src/components/client/accounts/Account.tsx
@@ -4,6 +4,7 @@ import {
   Grid,
   Icon,
   IconButton,
+  Tag,
   Tooltip,
   useBreakpointValue,
   Wrap,
@@ -14,6 +15,7 @@ import { useAccount } from "../../../hooks/useAccount";
 import { useAccountType } from "../../../hooks/useAccountType";
 import { useInstruction } from "../../../hooks/useInstruction";
 import { useShallowSessionStoreWithUndo } from "../../../hooks/useSessionStore";
+import { IAccountTypeConfigNamed } from "../../../types/internal";
 import { removeFrom } from "../../../utils/sortable";
 import { DragHandle } from "../../common/DragHandle";
 import { EditableName } from "../../common/EditableName";
@@ -27,7 +29,7 @@ export const Account: React.FC<{
 }> = ({ index }) => {
   const { id, isAnchor, useShallowGet, update } = useAccount();
   const { update: updateInstruction } = useInstruction();
-  const { type, isConfigurable: isTypeConfigurable } = useAccountType();
+  const { type, config, isConfigurable: isTypeConfigurable } = useAccountType();
 
   const [keypairs, setSession] = useShallowSessionStoreWithUndo((state) => [
     state.keypairs,
@@ -93,7 +95,11 @@ export const Account: React.FC<{
 
         <Wrap
           // TODO ignores other future tags
-          pt={isTypeConfigurable ? "1" : undefined}
+          pt={
+            isTypeConfigurable || config?.hasOwnProperty("name")
+              ? "1"
+              : undefined
+          }
         >
           {/* TODO */}
           {/* {type === "ata" && (
@@ -101,6 +107,10 @@ export const Account: React.FC<{
           )} */}
 
           {type === "pda" && <PdaTypeConfig />}
+
+          {config?.hasOwnProperty("name") && (
+            <Tag size="sm">{(config as IAccountTypeConfigNamed).name}</Tag>
+          )}
 
           {/* TODO account balance */}
         </Wrap>

--- a/src/components/client/accounts/AccountTypeButton.tsx
+++ b/src/components/client/accounts/AccountTypeButton.tsx
@@ -26,7 +26,8 @@ const TYPES: AccountTypeType[] = [
   "wallet",
   "keypair",
   "pda",
-  "ata",
+  // TODO implement
+  // "ata",
   "program",
   "sysvar",
   "unspecified",

--- a/src/components/client/accounts/type-configs/PdaTypeConfig.tsx
+++ b/src/components/client/accounts/type-configs/PdaTypeConfig.tsx
@@ -74,6 +74,7 @@ export const PdaTypeConfig: React.FC = () => {
                   <IconButton
                     size="xs"
                     aria-label="Confirm"
+                    colorScheme="teal"
                     icon={<AddIcon />}
                     onClick={add}
                   />
@@ -81,7 +82,7 @@ export const PdaTypeConfig: React.FC = () => {
 
                 <Wrap mt="3" spacing="1">
                   {seeds.map((seed, index) => (
-                    <Tag colorScheme="blue" noOfLines={1} key={index}>
+                    <Tag colorScheme="blue" key={index} wordBreak="break-all">
                       {seed}
                       <IconButton
                         ml="1"
@@ -106,7 +107,6 @@ export const PdaTypeConfig: React.FC = () => {
               <PopoverFooter>
                 <HStack>
                   <Button
-                    colorScheme="teal"
                     size="xs"
                     onClick={() => {
                       populate();

--- a/src/components/client/accounts/type-configs/PdaTypeConfig.tsx
+++ b/src/components/client/accounts/type-configs/PdaTypeConfig.tsx
@@ -12,6 +12,7 @@ import {
   PopoverTrigger,
   Portal,
   Tag,
+  Text,
   Wrap,
 } from "@chakra-ui/react";
 import React, { useRef, useState } from "react";
@@ -22,6 +23,7 @@ import { IAccountTypeConfigPda } from "../../../../types/internal";
 
 export const PdaTypeConfig: React.FC = () => {
   const [seed, setSeed] = useState("");
+  const [error, setError] = useState("");
   const { config, update, populate } = useAccountType();
   const initialFocusRef = useRef(null);
 
@@ -32,6 +34,16 @@ export const PdaTypeConfig: React.FC = () => {
       state.config = { seeds: [...seeds, seed] };
     });
     setSeed("");
+  };
+
+  const generate = (onClose: () => void) => () => {
+    try {
+      setError("");
+      populate();
+      onClose();
+    } catch (e) {
+      setError((e as Error).toString());
+    }
   };
 
   return (
@@ -106,15 +118,14 @@ export const PdaTypeConfig: React.FC = () => {
 
               <PopoverFooter>
                 <HStack>
-                  <Button
-                    size="xs"
-                    onClick={() => {
-                      populate();
-                      onClose();
-                    }}
-                  >
+                  <Button size="xs" onClick={generate(onClose)}>
                     Done
                   </Button>
+                  {error && (
+                    <Text ml="2" color="red.500" fontSize="sm">
+                      {error}
+                    </Text>
+                  )}
                 </HStack>
               </PopoverFooter>
             </PopoverContent>

--- a/src/components/common/AccountAutoComplete.tsx
+++ b/src/components/common/AccountAutoComplete.tsx
@@ -167,11 +167,12 @@ const OPTIONS: Option[] = [
     value: "pda",
     type: "type",
   },
-  {
-    label: "Associated token account",
-    value: "ata",
-    type: "type",
-  },
+  // TODO implement
+  // {
+  //   label: "Associated token account",
+  //   value: "ata",
+  //   type: "type",
+  // },
   {
     label: "Program",
     value: "program",


### PR DESCRIPTION
Also fixed:

* wrapping long seeds
* primary button in seed popover so users don't ignore the add button